### PR TITLE
Feature - 26 create library administrator endpoints

### DIFF
--- a/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -23,26 +24,26 @@ public class LibraryAdministratorController {
     @GetMapping("/librarians")
     public ResponseEntity<?> getLibrarians(
             @RequestParam(required = false) String username,
-            @RequestParam String libraryAdminEmail) {
+            Authentication authentication) {
         if (username != null) {
-            return ResponseEntity.ok(libraryAdministratorService.findLibrarianByUsername(username, libraryAdminEmail));
+            return ResponseEntity.ok(libraryAdministratorService.findLibrarianByUsername(username, authentication));
         }
-        return ResponseEntity.ok(libraryAdministratorService.getAllLibrarians(libraryAdminEmail));
+        return ResponseEntity.ok(libraryAdministratorService.getAllLibrarians(authentication));
     }
 
     @PostMapping("/librarians")
     public ResponseEntity<?> addLibrarian(
             @RequestBody @Valid CreateLibrarianDTO createLibrarianDTO,
-            @RequestParam String libraryAdminEmail) {
-        CreateLibrarianResponseDTO addedLibrarian = authService.createLibrarian(createLibrarianDTO, libraryAdminEmail);
+            Authentication authentication) {
+        CreateLibrarianResponseDTO addedLibrarian = authService.createLibrarian(createLibrarianDTO, authentication);
         return ResponseEntity.status(HttpStatus.CREATED).body(addedLibrarian);
     }
 
     @DeleteMapping("/librarians/{username}")
     public ResponseEntity<?> removeLibrarian(
             @PathVariable String username,
-            @RequestParam String libraryAdminEmail) {
-        libraryAdministratorService.deleteLibrarian(username, libraryAdminEmail);
+            Authentication authentication) {
+        libraryAdministratorService.deleteLibrarian(username, authentication);
         return ResponseEntity.noContent().build();
     }
 
@@ -50,8 +51,8 @@ public class LibraryAdministratorController {
     public ResponseEntity<?> resetLibrarianPassword(
             @PathVariable String username,
             @RequestParam String newPassword,
-            @RequestParam String libraryAdminEmail) {
-        CreateLibrarianResponseDTO updatedLibrarian = libraryAdministratorService.resetLibrarianPassword(username, newPassword, libraryAdminEmail);
+            Authentication authentication) {
+        CreateLibrarianResponseDTO updatedLibrarian = libraryAdministratorService.resetLibrarianPassword(username, newPassword, authentication);
         return ResponseEntity.ok(updatedLibrarian);
     }
 }

--- a/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
@@ -1,0 +1,57 @@
+package edu.zut.bookrider.controller;
+
+import edu.zut.bookrider.dto.CreateLibrarianDTO;
+import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.security.AuthService;
+import edu.zut.bookrider.service.LibraryAdministratorService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/library-admins")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('library_administrator')")
+public class LibraryAdministratorController {
+
+    private final LibraryAdministratorService libraryAdministratorService;
+    private final AuthService authService;
+
+    @GetMapping("/librarians")
+    public ResponseEntity<?> getLibrarians(
+            @RequestParam(required = false) String username,
+            @RequestParam String libraryAdminEmail) {
+        if (username != null) {
+            return ResponseEntity.ok(libraryAdministratorService.findLibrarianByUsername(username, libraryAdminEmail));
+        }
+        return ResponseEntity.ok(libraryAdministratorService.getAllLibrarians(libraryAdminEmail));
+    }
+
+    @PostMapping("/librarians")
+    public ResponseEntity<?> addLibrarian(
+            @RequestBody @Valid CreateLibrarianDTO createLibrarianDTO,
+            @RequestParam String libraryAdminEmail) {
+        CreateLibrarianResponseDTO addedLibrarian = authService.createLibrarian(createLibrarianDTO, libraryAdminEmail);
+        return ResponseEntity.status(HttpStatus.CREATED).body(addedLibrarian);
+    }
+
+    @DeleteMapping("/librarians/{username}")
+    public ResponseEntity<?> removeLibrarian(
+            @PathVariable String username,
+            @RequestParam String libraryAdminEmail) {
+        libraryAdministratorService.deleteLibrarian(username, libraryAdminEmail);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/librarians/reset-password/{username}")
+    public ResponseEntity<?> resetLibrarianPassword(
+            @PathVariable String username,
+            @RequestParam String newPassword,
+            @RequestParam String libraryAdminEmail) {
+        CreateLibrarianResponseDTO updatedLibrarian = libraryAdministratorService.resetLibrarianPassword(username, newPassword, libraryAdminEmail);
+        return ResponseEntity.ok(updatedLibrarian);
+    }
+}

--- a/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
@@ -2,6 +2,7 @@ package edu.zut.bookrider.controller;
 
 import edu.zut.bookrider.dto.CreateLibrarianDTO;
 import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.dto.LibrarianDTO;
 import edu.zut.bookrider.security.AuthService;
 import edu.zut.bookrider.service.LibraryAdministratorService;
 import jakarta.validation.Valid;
@@ -52,7 +53,7 @@ public class LibraryAdministratorController {
             @PathVariable String username,
             @RequestParam String newPassword,
             Authentication authentication) {
-        CreateLibrarianResponseDTO updatedLibrarian = libraryAdministratorService.resetLibrarianPassword(username, newPassword, authentication);
+        LibrarianDTO updatedLibrarian = libraryAdministratorService.resetLibrarianPassword(username, newPassword, authentication);
         return ResponseEntity.ok(updatedLibrarian);
     }
 }

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateLibrarianDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateLibrarianDTO.java
@@ -1,5 +1,6 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +9,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateLibrarianDTO {
+
+    @NotNull(message = "Username cannot be null")
     private String username;
+
+    @NotNull(message = "First name cannot be null")
     private String firstName;
+
+    @NotNull(message = "Last name cannot be null")
     private String lastName;
 }

--- a/backend/src/main/java/edu/zut/bookrider/dto/LibrarianDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/LibrarianDTO.java
@@ -1,0 +1,13 @@
+package edu.zut.bookrider.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class LibrarianDTO {
+    private String id;
+    private String username;
+    private String firstName;
+    private String lastName;
+}

--- a/backend/src/main/java/edu/zut/bookrider/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/edu/zut/bookrider/exception/GlobalExceptionHandler.java
@@ -134,6 +134,12 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(PasswordNotValidException.class)
+    public ResponseEntity<ApiErrorResponseDTO> handlePasswordNotValidException(PasswordNotValidException ex) {
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400,  ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(MissingAddressException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleMissingAddressException(MissingAddressException ex) {
         ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(422,  ex.getMessage());

--- a/backend/src/main/java/edu/zut/bookrider/exception/PasswordNotValidException.java
+++ b/backend/src/main/java/edu/zut/bookrider/exception/PasswordNotValidException.java
@@ -1,0 +1,7 @@
+package edu.zut.bookrider.exception;
+
+public class PasswordNotValidException extends RuntimeException {
+    public PasswordNotValidException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/edu/zut/bookrider/mapper/user/LibrarianReadMapper.java
+++ b/backend/src/main/java/edu/zut/bookrider/mapper/user/LibrarianReadMapper.java
@@ -1,0 +1,21 @@
+package edu.zut.bookrider.mapper.user;
+
+import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.mapper.Mapper;
+import edu.zut.bookrider.model.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LibrarianReadMapper implements Mapper<User, CreateLibrarianResponseDTO> {
+
+    @Override
+    public CreateLibrarianResponseDTO map(User user) {
+        return new CreateLibrarianResponseDTO(
+                user.getId(),
+                user.getUsername(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getPassword()
+        );
+    }
+}

--- a/backend/src/main/java/edu/zut/bookrider/mapper/user/LibrarianReadMapper.java
+++ b/backend/src/main/java/edu/zut/bookrider/mapper/user/LibrarianReadMapper.java
@@ -1,21 +1,20 @@
 package edu.zut.bookrider.mapper.user;
 
-import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.dto.LibrarianDTO;
 import edu.zut.bookrider.mapper.Mapper;
 import edu.zut.bookrider.model.User;
 import org.springframework.stereotype.Component;
 
 @Component
-public class LibrarianReadMapper implements Mapper<User, CreateLibrarianResponseDTO> {
+public class LibrarianReadMapper implements Mapper<User, LibrarianDTO> {
 
     @Override
-    public CreateLibrarianResponseDTO map(User user) {
-        return new CreateLibrarianResponseDTO(
+    public LibrarianDTO map(User user) {
+        return new LibrarianDTO(
                 user.getId(),
                 user.getUsername(),
                 user.getFirstName(),
-                user.getLastName(),
-                user.getPassword()
+                user.getLastName()
         );
     }
 }

--- a/backend/src/main/java/edu/zut/bookrider/security/AuthService.java
+++ b/backend/src/main/java/edu/zut/bookrider/security/AuthService.java
@@ -8,6 +8,7 @@ import edu.zut.bookrider.model.User;
 import edu.zut.bookrider.repository.RoleRepository;
 import edu.zut.bookrider.repository.UserRepository;
 import edu.zut.bookrider.service.UserIdGeneratorService;
+import edu.zut.bookrider.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -31,6 +32,7 @@ public class AuthService {
     private final RoleRepository roleRepository;
     private final UserIdGeneratorService userIdGeneratorService;
     private final PasswordEncoder passwordEncoder;
+    private final UserService userService;
 
     public String authenticateBasicAccount(LoginRequestDTO loginRequestDTO, String role) throws AuthenticationException {
         Authentication authenticationRequest = new UsernamePasswordAuthenticationToken(
@@ -110,10 +112,9 @@ public class AuthService {
 
     public CreateLibrarianResponseDTO createLibrarian(
             @Valid CreateLibrarianDTO createLibrarianDTO,
-            String libraryAdminEmail) {
+            Authentication authentication) {
 
-        User libraryAdmin = userRepository.findByEmailAndRoleName(libraryAdminEmail, "library_administrator")
-                .orElseThrow(() -> new IllegalArgumentException("Library admin with the provided email doesn't exist"));
+        User libraryAdmin = userService.getUser(authentication);
 
         Library library = libraryAdmin.getLibrary();
 

--- a/backend/src/main/java/edu/zut/bookrider/service/LibraryAdministratorService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/LibraryAdministratorService.java
@@ -1,6 +1,6 @@
 package edu.zut.bookrider.service;
 
-import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.dto.LibrarianDTO;
 import edu.zut.bookrider.exception.PasswordNotValidException;
 import edu.zut.bookrider.mapper.user.LibrarianReadMapper;
 import edu.zut.bookrider.model.User;
@@ -35,7 +35,7 @@ public class LibraryAdministratorService {
     }
 
     @Transactional
-    public CreateLibrarianResponseDTO resetLibrarianPassword(String username, String newPassword, Authentication authentication) {
+    public LibrarianDTO resetLibrarianPassword(String username, String newPassword, Authentication authentication) {
         User libraryAdmin = userService.getUser(authentication);
         Integer libraryId = libraryAdmin.getLibrary().getId();
 
@@ -56,7 +56,7 @@ public class LibraryAdministratorService {
         return librarianReadMapper.map(librarian);
     }
 
-    public List<CreateLibrarianResponseDTO> getAllLibrarians(Authentication authentication) {
+    public List<LibrarianDTO> getAllLibrarians(Authentication authentication) {
         User libraryAdmin = userService.getUser(authentication);
         List<User> librarians = userService.getAllLibrarians(libraryAdmin);
 
@@ -65,7 +65,7 @@ public class LibraryAdministratorService {
                 .toList();
     }
 
-    public CreateLibrarianResponseDTO findLibrarianByUsername(String username, Authentication authentication) {
+    public LibrarianDTO findLibrarianByUsername(String username, Authentication authentication) {
         User libraryAdmin = userService.getUser(authentication);
         Integer libraryId = libraryAdmin.getLibrary().getId();
 

--- a/backend/src/main/java/edu/zut/bookrider/service/LibraryAdministratorService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/LibraryAdministratorService.java
@@ -1,0 +1,85 @@
+package edu.zut.bookrider.service;
+
+import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.exception.PasswordNotValidException;
+import edu.zut.bookrider.exception.UserNotFoundException;
+import edu.zut.bookrider.mapper.user.LibrarianReadMapper;
+import edu.zut.bookrider.model.User;
+import edu.zut.bookrider.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class LibraryAdministratorService {
+
+    private static final String PASSWORD_PATTERN = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final LibrarianReadMapper librarianReadMapper;
+
+    @Transactional
+    public void deleteLibrarian(String username, String libraryAdminEmail) {
+        User libraryAdmin = findLibraryAdminByEmail(libraryAdminEmail);
+        Integer libraryId = libraryAdmin.getLibrary().getId();
+
+        User librarian = findLibrarianByUsernameAndLibraryId(username, libraryId);
+
+        userRepository.delete(librarian);
+    }
+
+    @Transactional
+    public CreateLibrarianResponseDTO resetLibrarianPassword(String username, String newPassword, String libraryAdminEmail) {
+        User libraryAdmin = findLibraryAdminByEmail(libraryAdminEmail);
+        Integer libraryId = libraryAdmin.getLibrary().getId();
+
+        User librarian = findLibrarianByUsernameAndLibraryId(username, libraryId);
+
+        if (newPassword.matches(PASSWORD_PATTERN)) {
+            librarian.setPassword(passwordEncoder.encode(newPassword));
+        } else {
+            throw new PasswordNotValidException(
+                    "Password must contain at least one uppercase letter, " +
+                    "one lowercase letter, one digit, and one special character : @$!%*?&. " +
+                    "It must be at least 8 characters long."
+            );
+        }
+
+        userRepository.save(librarian);
+
+        return librarianReadMapper.map(librarian);
+    }
+
+    public List<CreateLibrarianResponseDTO> getAllLibrarians(String libraryAdminEmail) {
+        User libraryAdmin = findLibraryAdminByEmail(libraryAdminEmail);
+        Integer libraryId = libraryAdmin.getLibrary().getId();
+
+        return userRepository.findAll().stream()
+                .filter(user -> "librarian".equals(user.getRole().getName()) && user.getLibrary().getId().equals(libraryId))
+                .map(librarianReadMapper::map)
+                .toList();
+    }
+
+    public CreateLibrarianResponseDTO findLibrarianByUsername(String username, String libraryAdminEmail) {
+        User libraryAdmin = findLibraryAdminByEmail(libraryAdminEmail);
+        Integer libraryId = libraryAdmin.getLibrary().getId();
+
+        User librarian = findLibrarianByUsernameAndLibraryId(username, libraryId);
+        return librarianReadMapper.map(librarian);
+    }
+
+    private User findLibraryAdminByEmail(String libraryAdminEmail) {
+        return userRepository.findByEmailAndRoleName(libraryAdminEmail, "library_administrator")
+                .orElseThrow(() -> new UserNotFoundException("Library admin with the provided email doesn't exist"));
+    }
+
+    private User findLibrarianByUsernameAndLibraryId(String username, Integer libraryId) {
+        return userRepository.findByUsernameAndLibraryId(username, libraryId)
+                .orElseThrow(() -> new UserNotFoundException("Librarian with the provided username " + username + " not found"));
+    }
+}

--- a/backend/src/main/java/edu/zut/bookrider/service/UserService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/UserService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Objects;
 
 @RequiredArgsConstructor
@@ -37,5 +38,18 @@ public class UserService {
 
         return userRepository.findByEmailAndRoleName(userEmail, role)
                 .orElseThrow(() -> new UserNotFoundException("User not found"));
+    }
+
+    public User findLibrarianByUsernameAndLibraryId(String username, Integer libraryId) {
+        return userRepository.findByUsernameAndLibraryId(username, libraryId)
+                .orElseThrow(() -> new UserNotFoundException("Librarian with the provided username " + username + " not found"));
+    }
+
+    public List<User> getAllLibrarians(User libraryAdmin) {
+        Integer libraryId = libraryAdmin.getLibrary().getId();
+
+        return userRepository.findAll().stream()
+                .filter(user -> "librarian".equals(user.getRole().getName()) && user.getLibrary().getId().equals(libraryId))
+                .toList();
     }
 }

--- a/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdministratorControllerIT.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdministratorControllerIT.java
@@ -1,0 +1,191 @@
+package edu.zut.bookrider.integration.controller;
+
+import edu.zut.bookrider.model.Address;
+import edu.zut.bookrider.model.Library;
+import edu.zut.bookrider.model.Role;
+import edu.zut.bookrider.model.User;
+import edu.zut.bookrider.repository.AddressRepository;
+import edu.zut.bookrider.repository.LibraryRepository;
+import edu.zut.bookrider.repository.RoleRepository;
+import edu.zut.bookrider.repository.UserRepository;
+import edu.zut.bookrider.service.UserIdGeneratorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class LibraryAdministratorControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private UserIdGeneratorService userIdGeneratorService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    @Autowired
+    private LibraryRepository libraryRepository;
+
+    private User libraryAdminReference;
+    private User librarianReference;
+
+    @BeforeEach
+    void setUp() {
+        Address address = new Address();
+        address.setPostalCode("12312");
+        address.setCity("Szczecin");
+        address.setStreet("Wyszynskiego 10");
+        address.setLatitude(BigDecimal.valueOf(10.0));
+        address.setLongitude(BigDecimal.valueOf(10.0));
+        Address savedAddress = addressRepository.save(address);
+
+        Library library = new Library();
+        library.setAddress(savedAddress);
+        library.setName("Library LACIT");
+        library.setPhoneNumber("123123123");
+        library.setEmail("library_lacit@test.com");
+        Library savedLibrary = libraryRepository.save(library);
+
+        Role libraryAdminRole = roleRepository.findByName("library_administrator").orElseThrow();
+        User libraryAdmin = new User();
+        libraryAdmin.setId(userIdGeneratorService.generateUniqueId());
+        libraryAdmin.setEmail("library_administator@gmail.com");
+        libraryAdmin.setRole(libraryAdminRole);
+        libraryAdmin.setLibrary(savedLibrary);
+        libraryAdmin.setIsVerified(true);
+        libraryAdmin.setPassword(passwordEncoder.encode("password"));
+        libraryAdminReference = userRepository.save(libraryAdmin);
+
+        Role librarianRole = roleRepository.findByName("librarian").orElseThrow();
+        User librarian = new User();
+        librarian.setId(userIdGeneratorService.generateUniqueId());
+        librarian.setRole(librarianRole);
+        librarian.setLibrary(savedLibrary);
+        librarian.setUsername("librarian1");
+        librarian.setPassword(passwordEncoder.encode("password"));
+        librarian.setFirstName("Adam");
+        librarian.setLastName("Smith");
+        librarianReference = userRepository.save(librarian);
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenValidData_thenReturnOkAndLibrarian() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/library-admins/librarians")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(notNullValue()))
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].username").value("librarian1"))
+                .andExpect(jsonPath("$[0].firstName").value("Adam"))
+                .andExpect(jsonPath("$[0].lastName").value("Smith"));
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenValidData_thenReturnOkAndLibrarians() throws Exception {
+
+        Role librarianRole = roleRepository.findByName("librarian").orElseThrow();
+        User librarian = new User();
+        librarian.setId(userIdGeneratorService.generateUniqueId());
+        librarian.setRole(librarianRole);
+        librarian.setLibrary(libraryAdminReference.getLibrary());
+        librarian.setUsername("librarian2");
+        librarian.setPassword(passwordEncoder.encode("password"));
+        librarian.setFirstName("Michael");
+        librarian.setLastName("Smith");
+        userRepository.save(librarian);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/library-admins/librarians")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(notNullValue()))
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].username").value("librarian1"))
+                .andExpect(jsonPath("$[0].firstName").value("Adam"))
+                .andExpect(jsonPath("$[0].lastName").value("Smith"))
+                .andExpect(jsonPath("$[1].username").value("librarian2"))
+                .andExpect(jsonPath("$[1].firstName").value("Michael"))
+                .andExpect(jsonPath("$[1].lastName").value("Smith"));
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenValidData_thenReturnOkAndJustOneLibrarian() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/library-admins/librarians")
+                        .param("username", librarianReference.getUsername())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string(notNullValue()))
+                .andExpect(jsonPath("$.username").value(librarianReference.getUsername()))
+                .andExpect(jsonPath("$.firstName").value("Adam"))
+                .andExpect(jsonPath("$.lastName").value("Smith"));
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenValidData_thenReturnNoContentAndRemoveLibrarian() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/library-admins/librarians/{username}", librarianReference.getUsername())
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNoContent());
+
+        Optional<User> deletedUser = userRepository.findById(librarianReference.getId());
+        assertFalse(deletedUser.isPresent(), "Librarian should not exist after deletion");
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenValidData_thenReturnOkAndUpdateLibrarianPassword() throws Exception {
+
+        assertTrue(passwordEncoder.matches("password", librarianReference.getPassword()));
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/library-admins/librarians/reset-password/{username}", librarianReference.getUsername())
+                        .param("newPassword", "Password1@")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        assertTrue(passwordEncoder.matches("Password1@", librarianReference.getPassword()));
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenWrongPasswordFormat_thenReturnBadRequest() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/library-admins/librarians/reset-password/{username}", librarianReference.getUsername())
+                        .param("newPassword", "password")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
@@ -1,0 +1,116 @@
+package edu.zut.bookrider.unit.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.zut.bookrider.controller.LibraryAdministratorController;
+import edu.zut.bookrider.dto.CreateLibrarianDTO;
+import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.service.LibraryAdministratorService;
+import edu.zut.bookrider.security.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class LibraryAdministratorControllerTest {
+
+    @Mock
+    private LibraryAdministratorService libraryAdministratorService;
+
+    @Mock
+    private AuthService authService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private LibraryAdministratorController libraryAdministratorController;
+
+    private MockMvc mockMvc;
+    private CreateLibrarianDTO createLibrarianDTO;
+    private CreateLibrarianResponseDTO librarianResponseDTO;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(libraryAdministratorController).build();
+
+        createLibrarianDTO = new CreateLibrarianDTO("test_user", "TestName", "TestLastName");
+        librarianResponseDTO = new CreateLibrarianResponseDTO("1", "test_user", "TestName", "TestLastName", "tempPassword");
+    }
+
+    @Test
+    void getAllLibrarians_shouldReturnAllLibrarians() throws Exception {
+        when(libraryAdministratorService.getAllLibrarians("admin@test.com"))
+                .thenReturn(List.of(librarianResponseDTO));
+
+        mockMvc.perform(get("/api/library-admins/librarians")
+                        .param("libraryAdminEmail", "admin@test.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].username").value("test_user"))
+                .andExpect(jsonPath("$[0].firstName").value("TestName"))
+                .andExpect(jsonPath("$[0].lastName").value("TestLastName"));
+
+        verify(libraryAdministratorService).getAllLibrarians("admin@test.com");
+    }
+
+    @Test
+    void addLibrarian_shouldReturnCreatedLibrarian() throws Exception {
+        when(authService.createLibrarian(any(CreateLibrarianDTO.class), eq("admin@test.com"))).thenReturn(librarianResponseDTO);
+
+        String jsonBody = objectMapper.writeValueAsString(createLibrarianDTO);
+
+        mockMvc.perform(post("/api/library-admins/librarians")
+                        .content(jsonBody)
+                        .param("libraryAdminEmail", "admin@test.com")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value("1"))
+                .andExpect(jsonPath("$.username").value("test_user"))
+                .andExpect(jsonPath("$.firstName").value("TestName"))
+                .andExpect(jsonPath("$.lastName").value("TestLastName"))
+                .andExpect(jsonPath("$.tempPassword").value("tempPassword"));
+
+        verify(authService).createLibrarian(any(CreateLibrarianDTO.class), eq("admin@test.com"));
+    }
+
+    @Test
+    void removeLibrarian_shouldReturnNoContent() throws Exception {
+        doNothing().when(libraryAdministratorService).deleteLibrarian(eq("test_user"), eq("admin@library.com"));
+
+        mockMvc.perform(delete("/api/library-admins/librarians/{username}", "test_user")
+                        .param("libraryAdminEmail", "admin@test.com"))
+                .andExpect(status().isNoContent());
+
+        verify(libraryAdministratorService).deleteLibrarian(eq("test_user"), eq("admin@test.com"));
+    }
+
+    @Test
+    void resetLibrarianPassword_shouldReturnUpdatedLibrarian() throws Exception {
+        when(libraryAdministratorService.resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq("admin@test.com")))
+                .thenReturn(librarianResponseDTO);
+
+        mockMvc.perform(patch("/api/library-admins/librarians/reset-password/{username}", "test_user")
+                        .param("newPassword", "newPassword")
+                        .param("libraryAdminEmail", "admin@test.com"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("test_user"))
+                .andExpect(jsonPath("$.firstName").value("TestName"))
+                .andExpect(jsonPath("$.lastName").value("TestLastName"));
+
+        verify(libraryAdministratorService).resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq("admin@test.com"));
+    }
+}

--- a/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.zut.bookrider.controller.LibraryAdministratorController;
 import edu.zut.bookrider.dto.CreateLibrarianDTO;
 import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.dto.LibrarianDTO;
 import edu.zut.bookrider.security.AuthService;
 import edu.zut.bookrider.service.LibraryAdministratorService;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +48,8 @@ public class LibraryAdministratorControllerTest {
 
     private MockMvc mockMvc;
     private CreateLibrarianDTO createLibrarianDTO;
-    private CreateLibrarianResponseDTO librarianResponseDTO;
+    private CreateLibrarianResponseDTO createLibrarianResponseDTO;
+    private LibrarianDTO librarianDTO;
 
     @Mock
     private Authentication authentication;
@@ -57,7 +59,8 @@ public class LibraryAdministratorControllerTest {
         mockMvc = MockMvcBuilders.standaloneSetup(libraryAdministratorController).build();
 
         createLibrarianDTO = new CreateLibrarianDTO("test_user", "TestName", "TestLastName");
-        librarianResponseDTO = new CreateLibrarianResponseDTO("1", "test_user", "TestName", "TestLastName", "tempPassword");
+        createLibrarianResponseDTO = new CreateLibrarianResponseDTO("1", "test_user", "TestName", "TestLastName", "tempPassword");
+        librarianDTO = new LibrarianDTO("1", "test_user", "TestName", "TestLastName");
 
         authentication = mock(Authentication.class);
         when(authentication.getName()).thenReturn("admin@test.com");
@@ -67,7 +70,7 @@ public class LibraryAdministratorControllerTest {
     @WithMockUser(username = "admin@test.com", roles = "library_administrator")
     void getAllLibrarians_shouldReturnAllLibrarians() throws Exception {
         when(libraryAdministratorService.getAllLibrarians(authentication))
-                .thenReturn(List.of(librarianResponseDTO));
+                .thenReturn(List.of(librarianDTO));
 
         mockMvc.perform(get("/api/library-admins/librarians")
                 .principal(authentication))
@@ -81,7 +84,7 @@ public class LibraryAdministratorControllerTest {
 
     @Test
     void addLibrarian_shouldReturnCreatedLibrarian() throws Exception {
-        when(authService.createLibrarian(any(CreateLibrarianDTO.class), eq(authentication))).thenReturn(librarianResponseDTO);
+        when(authService.createLibrarian(any(CreateLibrarianDTO.class), eq(authentication))).thenReturn(createLibrarianResponseDTO);
 
         SecurityContext securityContext = mock(SecurityContext.class);
         when(securityContext.getAuthentication()).thenReturn(authentication);
@@ -117,7 +120,7 @@ public class LibraryAdministratorControllerTest {
     @Test
     void resetLibrarianPassword_shouldReturnUpdatedLibrarian() throws Exception {
         when(libraryAdministratorService.resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq(authentication)))
-                .thenReturn(librarianResponseDTO);
+                .thenReturn(librarianDTO);
 
         mockMvc.perform(patch("/api/library-admins/librarians/reset-password/{username}", "test_user")
                         .principal(authentication)

--- a/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.zut.bookrider.controller.LibraryAdministratorController;
 import edu.zut.bookrider.dto.CreateLibrarianDTO;
 import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
-import edu.zut.bookrider.service.LibraryAdministratorService;
 import edu.zut.bookrider.security.AuthService;
+import edu.zut.bookrider.service.LibraryAdministratorService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +14,10 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -22,7 +26,8 @@ import java.util.List;
 
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
@@ -44,38 +49,49 @@ public class LibraryAdministratorControllerTest {
     private CreateLibrarianDTO createLibrarianDTO;
     private CreateLibrarianResponseDTO librarianResponseDTO;
 
+    @Mock
+    private Authentication authentication;
+
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(libraryAdministratorController).build();
 
         createLibrarianDTO = new CreateLibrarianDTO("test_user", "TestName", "TestLastName");
         librarianResponseDTO = new CreateLibrarianResponseDTO("1", "test_user", "TestName", "TestLastName", "tempPassword");
+
+        authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn("admin@test.com");
     }
 
     @Test
+    @WithMockUser(username = "admin@test.com", roles = "library_administrator")
     void getAllLibrarians_shouldReturnAllLibrarians() throws Exception {
-        when(libraryAdministratorService.getAllLibrarians("admin@test.com"))
+        when(libraryAdministratorService.getAllLibrarians(authentication))
                 .thenReturn(List.of(librarianResponseDTO));
 
         mockMvc.perform(get("/api/library-admins/librarians")
-                        .param("libraryAdminEmail", "admin@test.com"))
+                .principal(authentication))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].username").value("test_user"))
                 .andExpect(jsonPath("$[0].firstName").value("TestName"))
                 .andExpect(jsonPath("$[0].lastName").value("TestLastName"));
 
-        verify(libraryAdministratorService).getAllLibrarians("admin@test.com");
+        verify(libraryAdministratorService).getAllLibrarians(authentication);
     }
 
     @Test
     void addLibrarian_shouldReturnCreatedLibrarian() throws Exception {
-        when(authService.createLibrarian(any(CreateLibrarianDTO.class), eq("admin@test.com"))).thenReturn(librarianResponseDTO);
+        when(authService.createLibrarian(any(CreateLibrarianDTO.class), eq(authentication))).thenReturn(librarianResponseDTO);
+
+        SecurityContext securityContext = mock(SecurityContext.class);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
 
         String jsonBody = objectMapper.writeValueAsString(createLibrarianDTO);
 
         mockMvc.perform(post("/api/library-admins/librarians")
+                        .principal(authentication)
                         .content(jsonBody)
-                        .param("libraryAdminEmail", "admin@test.com")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("1"))
@@ -84,33 +100,33 @@ public class LibraryAdministratorControllerTest {
                 .andExpect(jsonPath("$.lastName").value("TestLastName"))
                 .andExpect(jsonPath("$.tempPassword").value("tempPassword"));
 
-        verify(authService).createLibrarian(any(CreateLibrarianDTO.class), eq("admin@test.com"));
+        verify(authService).createLibrarian(any(CreateLibrarianDTO.class), eq(authentication));
     }
 
     @Test
     void removeLibrarian_shouldReturnNoContent() throws Exception {
-        doNothing().when(libraryAdministratorService).deleteLibrarian(eq("test_user"), eq("admin@library.com"));
+        doNothing().when(libraryAdministratorService).deleteLibrarian(eq("test_user"), eq(authentication));
 
         mockMvc.perform(delete("/api/library-admins/librarians/{username}", "test_user")
-                        .param("libraryAdminEmail", "admin@test.com"))
+                        .principal(authentication))
                 .andExpect(status().isNoContent());
 
-        verify(libraryAdministratorService).deleteLibrarian(eq("test_user"), eq("admin@test.com"));
+        verify(libraryAdministratorService).deleteLibrarian(eq("test_user"), eq(authentication));
     }
 
     @Test
     void resetLibrarianPassword_shouldReturnUpdatedLibrarian() throws Exception {
-        when(libraryAdministratorService.resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq("admin@test.com")))
+        when(libraryAdministratorService.resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq(authentication)))
                 .thenReturn(librarianResponseDTO);
 
         mockMvc.perform(patch("/api/library-admins/librarians/reset-password/{username}", "test_user")
-                        .param("newPassword", "newPassword")
-                        .param("libraryAdminEmail", "admin@test.com"))
+                        .principal(authentication)
+                        .param("newPassword", "newPassword"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.username").value("test_user"))
                 .andExpect(jsonPath("$.firstName").value("TestName"))
                 .andExpect(jsonPath("$.lastName").value("TestLastName"));
 
-        verify(libraryAdministratorService).resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq("admin@test.com"));
+        verify(libraryAdministratorService).resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq(authentication));
     }
 }

--- a/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
@@ -9,17 +9,19 @@ import edu.zut.bookrider.model.Role;
 import edu.zut.bookrider.model.User;
 import edu.zut.bookrider.repository.UserRepository;
 import edu.zut.bookrider.service.LibraryAdministratorService;
+import edu.zut.bookrider.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
-
-import java.util.List;
-import java.util.Optional;
 
 public class LibraryAdministratorServiceTest {
 
@@ -29,12 +31,15 @@ public class LibraryAdministratorServiceTest {
     private LibrarianReadMapper librarianReadMapper;
     @Mock
     private PasswordEncoder passwordEncoder;
+    @Mock
+    private UserService userService;
     @InjectMocks
     private LibraryAdministratorService libraryAdministratorService;
 
     private User libraryAdmin;
     private User librarian;
     private CreateLibrarianResponseDTO librarianResponseDTO;
+    private Authentication authentication;
 
     @BeforeEach
     void setUp() {
@@ -56,25 +61,29 @@ public class LibraryAdministratorServiceTest {
         librarian.setLibrary(library);
 
         librarianResponseDTO = new CreateLibrarianResponseDTO(librarian.getId(), librarian.getUsername(), librarian.getFirstName(), librarian.getLastName(), "tempPassword");
+
+        authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn("admin@test.com");
     }
 
     @Test
     void deleteLibrarian_shouldDeleteLibrarianSuccessfully() {
-        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
-        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
+        when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
         doNothing().when(userRepository).delete(librarian);
 
-        libraryAdministratorService.deleteLibrarian("Test username", "admin@test.com");
+        libraryAdministratorService.deleteLibrarian("Test username", authentication);
 
         verify(userRepository, times(1)).delete(librarian);
     }
 
     @Test
     void deleteLibrarian_shouldThrowUserNotFoundException_whenLibrarianNotFound() {
-        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
-        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.empty());
+        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
+        when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId()))
+                .thenThrow(new UserNotFoundException("Librarian with the provided username Test username not found"));
 
-        assertThrows(UserNotFoundException.class, () -> libraryAdministratorService.deleteLibrarian("Test username", "admin@test.com"));
+        assertThrows(UserNotFoundException.class, () -> libraryAdministratorService.deleteLibrarian("Test username", authentication));
     }
 
     @Test
@@ -85,13 +94,13 @@ public class LibraryAdministratorServiceTest {
                 "123", "Test username", "Test FirstName", "Test LastName", "newPassword"
         );
 
-        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
-        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
+        when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
         when(passwordEncoder.encode(newPassword)).thenReturn("newPassword");
         when(userRepository.save(librarian)).thenReturn(librarian);
         when(librarianReadMapper.map(librarian)).thenReturn(librarianResponse);
 
-        CreateLibrarianResponseDTO result = libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, "admin@test.com");
+        CreateLibrarianResponseDTO result = libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, authentication);
 
         assertNotNull(result);
         assertEquals("newPassword", result.getTempPassword());
@@ -104,19 +113,19 @@ public class LibraryAdministratorServiceTest {
     @Test
     void resetLibrarianPassword_shouldThrowPasswordNotValidException_whenPasswordDoesNotMatchPattern() {
         String newPassword = "invalidPassword";
-        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
-        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
+        when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
 
-        assertThrows(PasswordNotValidException.class, () -> libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, "admin@test.com"));
+        assertThrows(PasswordNotValidException.class, () -> libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, authentication));
     }
 
     @Test
     void getAllLibrarians_shouldReturnAllLibrarians() {
-        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
-        when(userRepository.findAll()).thenReturn(List.of(librarian));
+        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
+        when(userService.getAllLibrarians(libraryAdmin)).thenReturn(List.of(librarian));
         when(librarianReadMapper.map(librarian)).thenReturn(librarianResponseDTO);
 
-        List<CreateLibrarianResponseDTO> result = libraryAdministratorService.getAllLibrarians("admin@test.com");
+        List<CreateLibrarianResponseDTO> result = libraryAdministratorService.getAllLibrarians(authentication);
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -125,11 +134,11 @@ public class LibraryAdministratorServiceTest {
 
     @Test
     void findLibrarianByUsername_shouldReturnLibrarianResponseDTO() {
-        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
-        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
+        when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
         when(librarianReadMapper.map(librarian)).thenReturn(librarianResponseDTO);
 
-        CreateLibrarianResponseDTO result = libraryAdministratorService.findLibrarianByUsername("Test username", "admin@test.com");
+        CreateLibrarianResponseDTO result = libraryAdministratorService.findLibrarianByUsername("Test username", authentication);
 
         assertNotNull(result);
         assertEquals("Test username", result.getUsername());

--- a/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
@@ -1,0 +1,137 @@
+package edu.zut.bookrider.unit.service;
+
+import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.exception.PasswordNotValidException;
+import edu.zut.bookrider.exception.UserNotFoundException;
+import edu.zut.bookrider.mapper.user.LibrarianReadMapper;
+import edu.zut.bookrider.model.Library;
+import edu.zut.bookrider.model.Role;
+import edu.zut.bookrider.model.User;
+import edu.zut.bookrider.repository.UserRepository;
+import edu.zut.bookrider.service.LibraryAdministratorService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.util.List;
+import java.util.Optional;
+
+public class LibraryAdministratorServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private LibrarianReadMapper librarianReadMapper;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @InjectMocks
+    private LibraryAdministratorService libraryAdministratorService;
+
+    private User libraryAdmin;
+    private User librarian;
+    private CreateLibrarianResponseDTO librarianResponseDTO;
+
+    @BeforeEach
+    void setUp() {
+        openMocks(this);
+
+        Library library = new Library();
+        library.setId(1);
+        library.setName("Test Library");
+
+        libraryAdmin = new User();
+        libraryAdmin.setEmail("admin@test.com");
+        libraryAdmin.setRole(new Role("library_administrator"));
+        libraryAdmin.setLibrary(library);
+
+        librarian = new User();
+        librarian.setUsername("Test username");
+        librarian.setPassword("password");
+        librarian.setRole(new Role("librarian"));
+        librarian.setLibrary(library);
+
+        librarianResponseDTO = new CreateLibrarianResponseDTO(librarian.getId(), librarian.getUsername(), librarian.getFirstName(), librarian.getLastName(), "tempPassword");
+    }
+
+    @Test
+    void deleteLibrarian_shouldDeleteLibrarianSuccessfully() {
+        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
+        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+        doNothing().when(userRepository).delete(librarian);
+
+        libraryAdministratorService.deleteLibrarian("Test username", "admin@test.com");
+
+        verify(userRepository, times(1)).delete(librarian);
+    }
+
+    @Test
+    void deleteLibrarian_shouldThrowUserNotFoundException_whenLibrarianNotFound() {
+        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
+        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.empty());
+
+        assertThrows(UserNotFoundException.class, () -> libraryAdministratorService.deleteLibrarian("Test username", "admin@test.com"));
+    }
+
+    @Test
+    void resetLibrarianPassword_shouldResetPasswordSuccessfully() {
+        String newPassword = "NewP@ssw0rd";
+
+        CreateLibrarianResponseDTO librarianResponse = new CreateLibrarianResponseDTO(
+                "123", "Test username", "Test FirstName", "Test LastName", "newPassword"
+        );
+
+        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
+        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+        when(passwordEncoder.encode(newPassword)).thenReturn("newPassword");
+        when(userRepository.save(librarian)).thenReturn(librarian);
+        when(librarianReadMapper.map(librarian)).thenReturn(librarianResponse);
+
+        CreateLibrarianResponseDTO result = libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, "admin@test.com");
+
+        assertNotNull(result);
+        assertEquals("newPassword", result.getTempPassword());
+        assertEquals("Test username", result.getUsername());
+        assertEquals("Test FirstName", result.getFirstName());
+        assertEquals("Test LastName", result.getLastName());
+        assertEquals("123", result.getId());
+    }
+
+    @Test
+    void resetLibrarianPassword_shouldThrowPasswordNotValidException_whenPasswordDoesNotMatchPattern() {
+        String newPassword = "invalidPassword";
+        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
+        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+
+        assertThrows(PasswordNotValidException.class, () -> libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, "admin@test.com"));
+    }
+
+    @Test
+    void getAllLibrarians_shouldReturnAllLibrarians() {
+        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
+        when(userRepository.findAll()).thenReturn(List.of(librarian));
+        when(librarianReadMapper.map(librarian)).thenReturn(librarianResponseDTO);
+
+        List<CreateLibrarianResponseDTO> result = libraryAdministratorService.getAllLibrarians("admin@test.com");
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("Test username", result.get(0).getUsername());
+    }
+
+    @Test
+    void findLibrarianByUsername_shouldReturnLibrarianResponseDTO() {
+        when(userRepository.findByEmailAndRoleName("admin@test.com", "library_administrator")).thenReturn(Optional.of(libraryAdmin));
+        when(userRepository.findByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(Optional.of(librarian));
+        when(librarianReadMapper.map(librarian)).thenReturn(librarianResponseDTO);
+
+        CreateLibrarianResponseDTO result = libraryAdministratorService.findLibrarianByUsername("Test username", "admin@test.com");
+
+        assertNotNull(result);
+        assertEquals("Test username", result.getUsername());
+    }
+}

--- a/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
@@ -39,7 +39,6 @@ public class LibraryAdministratorServiceTest {
 
     private User libraryAdmin;
     private User librarian;
-    private CreateLibrarianResponseDTO librarianResponseDTO;
     private LibrarianDTO librarianDTO;
     private Authentication authentication;
 
@@ -62,7 +61,6 @@ public class LibraryAdministratorServiceTest {
         librarian.setRole(new Role("librarian"));
         librarian.setLibrary(library);
 
-        librarianResponseDTO = new CreateLibrarianResponseDTO(librarian.getId(), librarian.getUsername(), librarian.getFirstName(), librarian.getLastName(), "tempPassword");
         librarianDTO = new LibrarianDTO("123", "Test username", "Test FirstName", "Test LastName");
 
 

--- a/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
@@ -1,6 +1,7 @@
 package edu.zut.bookrider.unit.service;
 
 import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
+import edu.zut.bookrider.dto.LibrarianDTO;
 import edu.zut.bookrider.exception.PasswordNotValidException;
 import edu.zut.bookrider.exception.UserNotFoundException;
 import edu.zut.bookrider.mapper.user.LibrarianReadMapper;
@@ -39,6 +40,7 @@ public class LibraryAdministratorServiceTest {
     private User libraryAdmin;
     private User librarian;
     private CreateLibrarianResponseDTO librarianResponseDTO;
+    private LibrarianDTO librarianDTO;
     private Authentication authentication;
 
     @BeforeEach
@@ -61,6 +63,8 @@ public class LibraryAdministratorServiceTest {
         librarian.setLibrary(library);
 
         librarianResponseDTO = new CreateLibrarianResponseDTO(librarian.getId(), librarian.getUsername(), librarian.getFirstName(), librarian.getLastName(), "tempPassword");
+        librarianDTO = new LibrarianDTO("123", "Test username", "Test FirstName", "Test LastName");
+
 
         authentication = mock(Authentication.class);
         when(authentication.getName()).thenReturn("admin@test.com");
@@ -90,20 +94,17 @@ public class LibraryAdministratorServiceTest {
     void resetLibrarianPassword_shouldResetPasswordSuccessfully() {
         String newPassword = "NewP@ssw0rd";
 
-        CreateLibrarianResponseDTO librarianResponse = new CreateLibrarianResponseDTO(
-                "123", "Test username", "Test FirstName", "Test LastName", "newPassword"
-        );
+        LibrarianDTO librarianDTO = new LibrarianDTO("123", "Test username", "Test FirstName", "Test LastName");
 
         when(userService.getUser(authentication)).thenReturn(libraryAdmin);
         when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
         when(passwordEncoder.encode(newPassword)).thenReturn("newPassword");
         when(userRepository.save(librarian)).thenReturn(librarian);
-        when(librarianReadMapper.map(librarian)).thenReturn(librarianResponse);
+        when(librarianReadMapper.map(librarian)).thenReturn(librarianDTO);
 
-        CreateLibrarianResponseDTO result = libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, authentication);
+        LibrarianDTO result = libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, authentication);
 
         assertNotNull(result);
-        assertEquals("newPassword", result.getTempPassword());
         assertEquals("Test username", result.getUsername());
         assertEquals("Test FirstName", result.getFirstName());
         assertEquals("Test LastName", result.getLastName());
@@ -123,9 +124,9 @@ public class LibraryAdministratorServiceTest {
     void getAllLibrarians_shouldReturnAllLibrarians() {
         when(userService.getUser(authentication)).thenReturn(libraryAdmin);
         when(userService.getAllLibrarians(libraryAdmin)).thenReturn(List.of(librarian));
-        when(librarianReadMapper.map(librarian)).thenReturn(librarianResponseDTO);
+        when(librarianReadMapper.map(librarian)).thenReturn(librarianDTO);
 
-        List<CreateLibrarianResponseDTO> result = libraryAdministratorService.getAllLibrarians(authentication);
+        List<LibrarianDTO> result = libraryAdministratorService.getAllLibrarians(authentication);
 
         assertNotNull(result);
         assertEquals(1, result.size());
@@ -136,9 +137,9 @@ public class LibraryAdministratorServiceTest {
     void findLibrarianByUsername_shouldReturnLibrarianResponseDTO() {
         when(userService.getUser(authentication)).thenReturn(libraryAdmin);
         when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
-        when(librarianReadMapper.map(librarian)).thenReturn(librarianResponseDTO);
+        when(librarianReadMapper.map(librarian)).thenReturn(librarianDTO);
 
-        CreateLibrarianResponseDTO result = libraryAdministratorService.findLibrarianByUsername("Test username", authentication);
+        LibrarianDTO result = libraryAdministratorService.findLibrarianByUsername("Test username", authentication);
 
         assertNotNull(result);
         assertEquals("Test username", result.getUsername());


### PR DESCRIPTION
Create New Librarian: Added an endpoint to allow the creation of a new librarian by providing necessary data  such as username, first name, and last name. 

Remove Librarian: Added an endpoint that enables the deletion of a librarian from the system by username. 

Reset Librarian's Password: Added an endpoint to reset a librarian's password. 

Get Librarians (Search by Name): Introduced an endpoint to fetch a list of librarians, with an option to search by name (first name or last name). If no matching librarians are found, the system returns all librarians