### PR TITLE
Resolves #73 - Librarian order endpoints

### DIFF
--- a/backend/sql/database_schema.sql
+++ b/backend/sql/database_schema.sql
@@ -218,6 +218,7 @@ CREATE TABLE orders
     payment_status VARCHAR(50) NOT NULL,
     delivery_photo_url TEXT,
     note_to_driver TEXT,
+    decline_reason TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     accepted_at TIMESTAMP DEFAULT NULL,

--- a/backend/sql/sample_data.sql
+++ b/backend/sql/sample_data.sql
@@ -165,7 +165,7 @@ VALUES
     (1, 'driving_licence', 'imgur.com/driver1-driving-licence', '2041-01-01');
 
 UPDATE driver_application_requests
-SET reviewed_by = 'YBWNYIBF1S', status = 'approved', reviewed_at = CURRENT_TIMESTAMP
+SET reviewed_by = 'YBWNYIBF1S', status = 'APPROVED', reviewed_at = CURRENT_TIMESTAMP
 WHERE id = 1;
 
 UPDATE users
@@ -190,7 +190,7 @@ VALUES
     (2, 'driving_licence', 'imgur.com/driver2-driving_licence', '2035-02-01');
 
 UPDATE driver_application_requests
-SET reviewed_by = 'YBWNYIBF1S', status = 'approved', reviewed_at = CURRENT_TIMESTAMP
+SET reviewed_by = 'YBWNYIBF1S', status = 'APPROVED', reviewed_at = CURRENT_TIMESTAMP
 WHERE id = 2;
 
 UPDATE users

--- a/backend/sql/sample_data.sql
+++ b/backend/sql/sample_data.sql
@@ -165,7 +165,7 @@ VALUES
     (1, 'driving_licence', 'imgur.com/driver1-driving-licence', '2041-01-01');
 
 UPDATE driver_application_requests
-SET reviewed_by = 'YBWNYIBF1S', status = 'accepted', reviewed_at = CURRENT_TIMESTAMP
+SET reviewed_by = 'YBWNYIBF1S', status = 'approved', reviewed_at = CURRENT_TIMESTAMP
 WHERE id = 1;
 
 UPDATE users
@@ -190,7 +190,7 @@ VALUES
     (2, 'driving_licence', 'imgur.com/driver2-driving_licence', '2035-02-01');
 
 UPDATE driver_application_requests
-SET reviewed_by = 'YBWNYIBF1S', status = 'accepted', reviewed_at = CURRENT_TIMESTAMP
+SET reviewed_by = 'YBWNYIBF1S', status = 'approved', reviewed_at = CURRENT_TIMESTAMP
 WHERE id = 2;
 
 UPDATE users

--- a/backend/src/main/java/edu/zut/bookrider/controller/OrderController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/OrderController.java
@@ -1,7 +1,9 @@
 package edu.zut.bookrider.controller;
 
+import edu.zut.bookrider.dto.DeclineOrderRequestDTO;
 import edu.zut.bookrider.dto.OrdersResponseDTO;
 import edu.zut.bookrider.service.OrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -41,9 +43,11 @@ public class OrderController {
 
     @PreAuthorize("hasRole('librarian')")
     @PatchMapping("/{orderId}/decline")
-    public ResponseEntity<?> declineOrder(@PathVariable Integer orderId) {
+    public ResponseEntity<?> declineOrder(
+            @PathVariable Integer orderId,
+            @RequestBody @Valid DeclineOrderRequestDTO declineOrderRequestDTO) {
 
-        orderService.declineOrder(orderId);
+        orderService.declineOrder(orderId, declineOrderRequestDTO);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/edu/zut/bookrider/controller/OrderController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/OrderController.java
@@ -1,0 +1,59 @@
+package edu.zut.bookrider.controller;
+
+import edu.zut.bookrider.dto.OrdersResponseDTO;
+import edu.zut.bookrider.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PreAuthorize("hasRole('user')")
+    @GetMapping("/user")
+    public ResponseEntity<?> getUserOrders(Authentication authentication) {
+
+        OrdersResponseDTO response = orderService.getUserOrders(authentication);
+        return ResponseEntity.ok(response);
+    }
+
+    @PreAuthorize("hasRole('librarian')")
+    @GetMapping("/librarian")
+    public ResponseEntity<?> getLibrarianOrders(Authentication authentication) {
+
+        OrdersResponseDTO response = orderService.getLibraryOrders(authentication);
+        return ResponseEntity.ok(response);
+    }
+
+    @PreAuthorize("hasRole('librarian')")
+    @PatchMapping("/{orderId}/accept")
+    public ResponseEntity<?> acceptOrder(@PathVariable Integer orderId) {
+
+        orderService.acceptOrder(orderId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('librarian')")
+    @PatchMapping("/{orderId}/decline")
+    public ResponseEntity<?> declineOrder(@PathVariable Integer orderId) {
+
+        orderService.declineOrder(orderId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('librarian')")
+    @PostMapping("/{orderId}/handover")
+    public ResponseEntity<?> handOverToDriver(
+            @PathVariable Integer orderId,
+            @RequestParam String driverId) {
+
+        orderService.handoverOrderToDriver(orderId, driverId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateOrderResponseDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateOrderResponseDTO.java
@@ -11,6 +11,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateOrderResponseDTO {
+    private Integer orderId;
     private String userId;
     private String libraryName;
     private String deliveryAddress;

--- a/backend/src/main/java/edu/zut/bookrider/dto/DeclineOrderRequestDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/DeclineOrderRequestDTO.java
@@ -1,0 +1,14 @@
+package edu.zut.bookrider.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeclineOrderRequestDTO {
+    @NotBlank(message = "Rejection reason is required")
+    private String reason;
+}

--- a/backend/src/main/java/edu/zut/bookrider/dto/OrdersResponseDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/OrdersResponseDTO.java
@@ -1,0 +1,15 @@
+package edu.zut.bookrider.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrdersResponseDTO {
+    private List<CreateOrderResponseDTO> activeOrders;
+    private List<CreateOrderResponseDTO> completedOrders;
+}

--- a/backend/src/main/java/edu/zut/bookrider/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/edu/zut/bookrider/exception/GlobalExceptionHandler.java
@@ -54,44 +54,44 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NoRouteFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleNoRouteFoundException(NoRouteFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400, ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(ExternalApiException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleExternalApiException(ExternalApiException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400, ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(503, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @ExceptionHandler(BookNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleBookNotFoundException(BookNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400, ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(LibraryNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleLibraryNotFoundException(LibraryNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400, ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(CategoryNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleCategoryNotFoundException(CategoryNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400, ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(PublisherNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handlePublisherNotFoundException(PublisherNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400, ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(LanguageNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleLanguageNotFoundException(LanguageNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400, ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404, ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(BadCredentialsException.class)
@@ -133,20 +133,20 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(OrderNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleOrderNotFoundException(OrderNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400,  ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404,  ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(DriverApplicationNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleDriverApplicationNotFoundException(DriverApplicationNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400,  ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404,  ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ApiErrorResponseDTO> handleUserNotFoundException(UserNotFoundException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400,  ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(404,  ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler(PasswordNotValidException.class)
@@ -171,6 +171,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiErrorResponseDTO> handleEmptyCartException(EmptyCartException ex) {
         ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400,  ex.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiErrorResponseDTO> handleIllegalStateException(IllegalStateException ex) {
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(409,  ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/edu/zut/bookrider/mapper/order/OrderMapper.java
+++ b/backend/src/main/java/edu/zut/bookrider/mapper/order/OrderMapper.java
@@ -23,6 +23,7 @@ public class OrderMapper implements Mapper<Order, CreateOrderResponseDTO> {
                 .toList();
 
         return new CreateOrderResponseDTO(
+                order.getId(),
                 order.getUser().getId(),
                 order.getLibrary().getName(),
                 order.getTargetAddress().getStreet(),

--- a/backend/src/main/java/edu/zut/bookrider/model/Order.java
+++ b/backend/src/main/java/edu/zut/bookrider/model/Order.java
@@ -57,6 +57,9 @@ public class Order extends BaseEntity<Integer> {
     @Column(name = "note_to_driver")
     private String noteToDriver;
 
+    @Column(name = "decline_reason")
+    private String declineReason;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/backend/src/main/java/edu/zut/bookrider/model/enums/OrderStatus.java
+++ b/backend/src/main/java/edu/zut/bookrider/model/enums/OrderStatus.java
@@ -6,5 +6,6 @@ public enum OrderStatus {
     PROCESSING,
     IN_TRANSIT,
     DELIVERED,
-    CANCELED
+    CANCELED,
+    DECLINED
 }

--- a/backend/src/main/java/edu/zut/bookrider/repository/OrderRepository.java
+++ b/backend/src/main/java/edu/zut/bookrider/repository/OrderRepository.java
@@ -1,7 +1,13 @@
 package edu.zut.bookrider.repository;
 
 import edu.zut.bookrider.model.Order;
+import edu.zut.bookrider.model.enums.OrderStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderRepository extends JpaRepository<Order, Integer> {
+
+    List<Order> findByUserIdAndStatusIn(String userId, List<OrderStatus> statuses);
+    List<Order> findByLibraryIdAndStatusIn(Integer libraryId, List<OrderStatus> statuses);
 }

--- a/backend/src/main/java/edu/zut/bookrider/service/OrderService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/OrderService.java
@@ -1,6 +1,7 @@
 package edu.zut.bookrider.service;
 
 import edu.zut.bookrider.dto.CreateOrderResponseDTO;
+import edu.zut.bookrider.dto.DeclineOrderRequestDTO;
 import edu.zut.bookrider.dto.OrdersResponseDTO;
 import edu.zut.bookrider.exception.OrderNotFoundException;
 import edu.zut.bookrider.mapper.order.OrderMapper;
@@ -124,7 +125,7 @@ public class OrderService {
     }
 
     @Transactional
-    public void declineOrder(Integer orderId) {
+    public void declineOrder(Integer orderId, DeclineOrderRequestDTO declineOrderRequestDTO) {
 
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("Order not found"));
@@ -137,6 +138,7 @@ public class OrderService {
 
         order.setStatus(OrderStatus.DECLINED);
         order.setLibrarian(librarian);
+        order.setDeclineReason(declineOrderRequestDTO.getReason());
         orderRepository.save(order);
     }
 

--- a/backend/src/main/java/edu/zut/bookrider/service/OrderService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/OrderService.java
@@ -1,16 +1,23 @@
 package edu.zut.bookrider.service;
 
+import edu.zut.bookrider.dto.CreateOrderResponseDTO;
+import edu.zut.bookrider.dto.OrdersResponseDTO;
+import edu.zut.bookrider.exception.OrderNotFoundException;
+import edu.zut.bookrider.mapper.order.OrderMapper;
 import edu.zut.bookrider.model.Order;
 import edu.zut.bookrider.model.OrderItem;
 import edu.zut.bookrider.model.ShoppingCartItem;
+import edu.zut.bookrider.model.User;
 import edu.zut.bookrider.model.enums.OrderItemStatus;
 import edu.zut.bookrider.model.enums.OrderStatus;
 import edu.zut.bookrider.model.enums.PaymentStatus;
 import edu.zut.bookrider.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,6 +26,8 @@ import java.util.stream.Collectors;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final UserService userService;
+    private final OrderMapper orderMapper;
 
     @Transactional
     public Order createOrderFromCartItem(ShoppingCartItem item) {
@@ -52,5 +61,101 @@ public class OrderService {
         order.setPaymentStatus(paymentStatus);
 
         return orderRepository.save(order);
+    }
+
+    public OrdersResponseDTO getUserOrders(Authentication authentication) {
+
+        User user = userService.getUser(authentication);
+
+        List<Order> activeOrders = orderRepository.findByUserIdAndStatusIn(
+                user.getId(), List.of(OrderStatus.PENDING, OrderStatus.ACCEPTED));
+
+        List<Order> completedOrders = orderRepository.findByUserIdAndStatusIn(
+                user.getId(), List.of(OrderStatus.DECLINED, OrderStatus.DELIVERED));
+
+        List<CreateOrderResponseDTO> activeOrderDtos = activeOrders.stream()
+                .map(orderMapper::map)
+                .toList();
+
+        List<CreateOrderResponseDTO> completedOrderDtos = completedOrders.stream()
+                .map(orderMapper::map)
+                .toList();
+
+        return new OrdersResponseDTO(activeOrderDtos, completedOrderDtos);
+    }
+
+    public OrdersResponseDTO getLibraryOrders(Authentication authentication) {
+
+        User librarian = userService.getUser(authentication);
+
+        List<Order> activeOrders = orderRepository.findByLibraryIdAndStatusIn(
+                librarian.getLibrary().getId(), List.of(OrderStatus.PENDING, OrderStatus.ACCEPTED));
+
+        List<Order> completedOrders = orderRepository.findByLibraryIdAndStatusIn(
+                librarian.getLibrary().getId(), List.of(OrderStatus.DECLINED, OrderStatus.DELIVERED));
+
+        List<CreateOrderResponseDTO> activeOrderDtos = activeOrders.stream()
+                .map(orderMapper::map)
+                .toList();
+
+        List<CreateOrderResponseDTO> completedOrderDtos = completedOrders.stream()
+                .map(orderMapper::map)
+                .toList();
+
+        return new OrdersResponseDTO(activeOrderDtos, completedOrderDtos);
+    }
+
+    @Transactional
+    public void acceptOrder(Integer orderId) {
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException("Order not found"));
+
+        if (order.getStatus() == OrderStatus.ACCEPTED || order.getStatus() == OrderStatus.DECLINED) {
+            throw new IllegalStateException("Order cannot be accepted because it is already accepted or declined");
+        }
+
+        User librarian = userService.getUser();
+
+        order.setStatus(OrderStatus.ACCEPTED);
+        order.setLibrarian(librarian);
+        order.setAcceptedAt(LocalDateTime.now());
+        orderRepository.save(order);
+    }
+
+    @Transactional
+    public void declineOrder(Integer orderId) {
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException("Order not found"));
+
+        if (order.getStatus() == OrderStatus.ACCEPTED || order.getStatus() == OrderStatus.DECLINED) {
+            throw new IllegalStateException("Order cannot be accepted because it is already accepted or declined");
+        }
+
+        User librarian = userService.getUser();
+
+        order.setStatus(OrderStatus.DECLINED);
+        order.setLibrarian(librarian);
+        orderRepository.save(order);
+    }
+
+    @Transactional
+    public void handoverOrderToDriver(Integer orderId, String providedDriverId) {
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException("Order not found"));
+
+        if (order.getStatus() != OrderStatus.ACCEPTED) {
+            throw new IllegalStateException("Order cannot be handed over unless it is in ACCEPTED state.");
+        }
+
+        if (!order.getDriver().getId().equals(providedDriverId)) {
+            throw new IllegalArgumentException("Provided driver ID does not match the driver assigned to the order.");
+        }
+
+        order.setStatus(OrderStatus.IN_TRANSIT);
+        order.setPickedUpAt(LocalDateTime.now());
+        orderRepository.save(order);
     }
 }

--- a/backend/src/test/java/edu/zut/bookrider/integration/controller/OrderControllerIT.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/controller/OrderControllerIT.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -20,7 +21,7 @@ import java.math.BigDecimal;
 
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -212,11 +213,15 @@ public class OrderControllerIT {
         order.setPaymentStatus(PaymentStatus.COMPLETED);
         order = orderRepository.save(order);
 
-        mockMvc.perform(MockMvcRequestBuilders.patch("/api/orders/" + order.getId() + "/decline"))
+        String rejectionReason = "The requested item is out of stock.";
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/orders/" + order.getId() + "/decline")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"reason\": \"" + rejectionReason + "\"}"))
                 .andExpect(status().isOk());
 
         Order updatedOrder = orderRepository.findById(order.getId()).orElseThrow();
         assertEquals(OrderStatus.DECLINED, updatedOrder.getStatus());
+        assertEquals(rejectionReason, updatedOrder.getDeclineReason());
     }
 
     @Test

--- a/backend/src/test/java/edu/zut/bookrider/integration/controller/OrderControllerIT.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/controller/OrderControllerIT.java
@@ -1,0 +1,320 @@
+package edu.zut.bookrider.integration.controller;
+
+import edu.zut.bookrider.model.*;
+import edu.zut.bookrider.model.enums.OrderStatus;
+import edu.zut.bookrider.model.enums.PaymentStatus;
+import edu.zut.bookrider.repository.*;
+import edu.zut.bookrider.service.UserIdGeneratorService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class OrderControllerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private UserIdGeneratorService userIdGeneratorService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private LibraryRepository libraryRepository;
+
+    @Autowired
+    private AddressRepository addressRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User user;
+    private User librarian;
+    private Library library;
+    private Address address;
+
+    @BeforeEach
+    void setUp() {
+
+        address = new Address();
+        address.setPostalCode("12312");
+        address.setCity("Szczecin");
+        address.setStreet("Wyszynskiego 10");
+        address.setLatitude(BigDecimal.valueOf(10.0));
+        address.setLongitude(BigDecimal.valueOf(10.0));
+        address = addressRepository.save(address);
+
+        Role userRole = roleRepository.findByName("user").orElseThrow();
+        user = new User();
+        user.setId(userIdGeneratorService.generateUniqueId());
+        user.setEmail("testuser@ocit.com");
+        user.setRole(userRole);
+        user.setPassword(passwordEncoder.encode("password"));
+        user = userRepository.save(user);
+
+        library = libraryRepository.findById(1).orElseThrow();
+
+        Role librarianRole = roleRepository.findByName("librarian").orElseThrow();
+        librarian = new User();
+        librarian.setId(userIdGeneratorService.generateUniqueId());
+        librarian.setUsername("testlibrarian1");
+        librarian.setFirstName("Adam");
+        librarian.setLastName("Smith");
+        librarian.setRole(librarianRole);
+        librarian.setLibrary(library);
+        librarian.setPassword(passwordEncoder.encode("password"));
+        librarian = userRepository.save(librarian);
+    }
+
+    @Test
+    @WithMockUser(username = "testuser@ocit.com:user", roles = {"user"})
+    void whenUserRequestsOrders_thenReturnUserOrders() throws Exception {
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.PENDING);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        orderRepository.save(order);
+
+        Order order2 = new Order();
+        order2.setUser(user);
+        order2.setLibrary(library);
+        order2.setStatus(OrderStatus.DELIVERED);
+        order2.setTargetAddress(address);
+        order2.setAmount(BigDecimal.valueOf(10));
+        order2.setPaymentStatus(PaymentStatus.COMPLETED);
+        orderRepository.save(order2);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/orders/user"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeOrders").isArray())
+                .andExpect(jsonPath("$.activeOrders", hasSize(greaterThan(0))))
+                .andExpect(jsonPath("$.completedOrders").isArray())
+                .andExpect(jsonPath("$.completedOrders", hasSize(greaterThan(0))));
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenLibrarianRequestsOrders_thenReturnLibraryOrders() throws Exception {
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.PENDING);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        orderRepository.save(order);
+
+        Order order2 = new Order();
+        order2.setUser(user);
+        order2.setLibrary(library);
+        order2.setStatus(OrderStatus.DELIVERED);
+        order2.setTargetAddress(address);
+        order2.setAmount(BigDecimal.valueOf(10));
+        order2.setPaymentStatus(PaymentStatus.COMPLETED);
+        orderRepository.save(order2);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/orders/librarian"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeOrders").isArray())
+                .andExpect(jsonPath("$.activeOrders", hasSize(greaterThan(0))))
+                .andExpect(jsonPath("$.completedOrders").isArray())
+                .andExpect(jsonPath("$.completedOrders", hasSize(greaterThan(0))));
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenLibrarianAcceptsOrder_thenStatusIsAccepted() throws Exception {
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.PENDING);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/orders/" + order.getId() + "/accept"))
+                .andExpect(status().isOk());
+
+        Order updatedOrder = orderRepository.findById(order.getId()).orElseThrow();
+        assertEquals(OrderStatus.ACCEPTED, updatedOrder.getStatus());
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenOrderIsAlreadyAcceptedOrDeclined_thenIllegalStateExceptionIsThrown() throws Exception {
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.ACCEPTED);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        order.setLibrarian(librarian);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/orders/" + order.getId() + "/accept"))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenOrderNotFound_thenOrderNotFoundExceptionIsThrown() throws Exception {
+
+        int nonExistentOrderId = 999999999;
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/orders/" + nonExistentOrderId + "/accept"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenLibrarianDeclinesOrder_thenStatusIsDeclined() throws Exception {
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.PENDING);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/orders/" + order.getId() + "/decline"))
+                .andExpect(status().isOk());
+
+        Order updatedOrder = orderRepository.findById(order.getId()).orElseThrow();
+        assertEquals(OrderStatus.DECLINED, updatedOrder.getStatus());
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenLibrarianHandoverOrderToDriver_thenStatusIsUpdated() throws Exception {
+
+        Role driverRole = roleRepository.findByName("driver").orElseThrow();
+        User driver = new User();
+        driver.setId(userIdGeneratorService.generateUniqueId());
+        driver.setRole(driverRole);
+        driver.setEmail("testdriver@ocit.com");
+        driver.setFirstName("Adam");
+        driver.setLastName("Driver");
+        driver.setPassword(passwordEncoder.encode("password"));
+        driver = userRepository.save(driver);
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.ACCEPTED);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        order.setDriver(driver);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/orders/" + order.getId() + "/handover")
+                        .param("driverId", driver.getId()))
+                .andExpect(status().isOk());
+
+        Order updatedOrder = orderRepository.findById(order.getId()).orElseThrow();
+        assertEquals(OrderStatus.IN_TRANSIT, updatedOrder.getStatus());
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenOrderIsNotAccepted_thenIllegalStateExceptionIsThrown() throws Exception {
+
+        Role driverRole = roleRepository.findByName("driver").orElseThrow();
+        User driver = new User();
+        driver.setId(userIdGeneratorService.generateUniqueId());
+        driver.setRole(driverRole);
+        driver.setEmail("testdriver@ocit.com");
+        driver.setFirstName("Adam");
+        driver.setLastName("Driver");
+        driver.setPassword(passwordEncoder.encode("password"));
+        driver = userRepository.save(driver);
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.PENDING);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        order.setDriver(driver);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/orders/" + order.getId() + "/handover")
+                        .param("driverId", driver.getId()))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @WithMockUser(username = "testlibrarian1:1", roles = {"librarian"})
+    void whenProvidedDriverIdDoesNotMatchAssignedDriver_thenIllegalArgumentExceptionIsThrown() throws Exception {
+
+        Role driverRole = roleRepository.findByName("driver").orElseThrow();
+        User driver1 = new User();
+        driver1.setId(userIdGeneratorService.generateUniqueId());
+        driver1.setRole(driverRole);
+        driver1.setEmail("testdriver1@ocit.com");
+        driver1.setFirstName("Adam");
+        driver1.setLastName("Driver");
+        driver1.setPassword(passwordEncoder.encode("password"));
+        driver1 = userRepository.save(driver1);
+
+        User driver2 = new User();
+        driver2.setId(userIdGeneratorService.generateUniqueId());
+        driver2.setRole(driverRole);
+        driver2.setEmail("testdriver2@ocit.com");
+        driver2.setFirstName("Bob");
+        driver2.setLastName("Driver");
+        driver2.setPassword(passwordEncoder.encode("password"));
+        driver2 = userRepository.save(driver2);
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setLibrary(library);
+        order.setStatus(OrderStatus.ACCEPTED);
+        order.setTargetAddress(address);
+        order.setAmount(BigDecimal.valueOf(10));
+        order.setPaymentStatus(PaymentStatus.COMPLETED);
+        order.setDriver(driver1);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/orders/" + order.getId() + "/handover")
+                        .param("driverId", driver2.getId()))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
- Users can display their active and past orders.
- Librarians can see the active and past orders.
- Librarians can accept active orders.
- Librarians can decline active orders after providing a rejection reason.
- Librarians can handle the book to the drivers, after providing the driver's ID assigned to a particular order.