### PR TITLE
Resolve #100 - Add password change endpoint for librarians

### DIFF
--- a/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/LibraryAdministratorController.java
@@ -2,7 +2,6 @@ package edu.zut.bookrider.controller;
 
 import edu.zut.bookrider.dto.CreateLibrarianDTO;
 import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
-import edu.zut.bookrider.dto.LibrarianDTO;
 import edu.zut.bookrider.security.AuthService;
 import edu.zut.bookrider.service.LibraryAdministratorService;
 import jakarta.validation.Valid;
@@ -50,10 +49,8 @@ public class LibraryAdministratorController {
 
     @PatchMapping("/librarians/reset-password/{username}")
     public ResponseEntity<?> resetLibrarianPassword(
-            @PathVariable String username,
-            @RequestParam String newPassword,
-            Authentication authentication) {
-        LibrarianDTO updatedLibrarian = libraryAdministratorService.resetLibrarianPassword(username, newPassword, authentication);
+            @PathVariable String username) {
+        CreateLibrarianResponseDTO updatedLibrarian = libraryAdministratorService.resetLibrarianPassword(username);
         return ResponseEntity.ok(updatedLibrarian);
     }
 }

--- a/backend/src/main/java/edu/zut/bookrider/controller/UserController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/UserController.java
@@ -1,15 +1,16 @@
 package edu.zut.bookrider.controller;
 
+import edu.zut.bookrider.dto.ChangePasswordDto;
 import edu.zut.bookrider.dto.IsVerifiedResponseDto;
 import edu.zut.bookrider.dto.UserIdResponseDto;
 import edu.zut.bookrider.model.User;
 import edu.zut.bookrider.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -33,5 +34,15 @@ public class UserController {
         boolean isVerified = user.getIsVerified();
 
         return ResponseEntity.ok(new IsVerifiedResponseDto(isVerified));
+    }
+    @PreAuthorize("hasRole('librarian')")
+    @PutMapping("/{username}/change-password")
+    public ResponseEntity<?> changePassword(
+            @PathVariable String username,
+            @RequestBody @Valid ChangePasswordDto changePasswordDto,
+            Authentication authentication) {
+
+        userService.changePassword(authentication, username, changePasswordDto);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/edu/zut/bookrider/controller/UserController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/UserController.java
@@ -8,7 +8,6 @@ import edu.zut.bookrider.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,14 +34,12 @@ public class UserController {
 
         return ResponseEntity.ok(new IsVerifiedResponseDto(isVerified));
     }
-    @PreAuthorize("hasRole('librarian')")
-    @PutMapping("/{username}/change-password")
-    public ResponseEntity<?> changePassword(
-            @PathVariable String username,
-            @RequestBody @Valid ChangePasswordDto changePasswordDto,
-            Authentication authentication) {
 
-        userService.changePassword(authentication, username, changePasswordDto);
+    @PutMapping("/change-password")
+    public ResponseEntity<?> changePassword(
+            @RequestBody @Valid ChangePasswordDto changePasswordDto) {
+
+        userService.changePassword(changePasswordDto);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/edu/zut/bookrider/dto/ChangePasswordDto.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/ChangePasswordDto.java
@@ -1,0 +1,21 @@
+package edu.zut.bookrider.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangePasswordDto {
+
+    @NotBlank(message = "Old password is required")
+    private String oldPassword;
+
+    @NotBlank(message = "New password is required")
+    private String newPassword;
+
+    @NotBlank(message = "Confirmation password is required")
+    private String confirmPassword;
+}

--- a/backend/src/main/java/edu/zut/bookrider/dto/ChangePasswordDto.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/ChangePasswordDto.java
@@ -15,7 +15,4 @@ public class ChangePasswordDto {
 
     @NotBlank(message = "New password is required")
     private String newPassword;
-
-    @NotBlank(message = "Confirmation password is required")
-    private String confirmPassword;
 }

--- a/backend/src/main/java/edu/zut/bookrider/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/edu/zut/bookrider/exception/GlobalExceptionHandler.java
@@ -155,10 +155,10 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
     }
 
-    @ExceptionHandler(PasswordNotValidException.class)
-    public ResponseEntity<ApiErrorResponseDTO> handlePasswordNotValidException(PasswordNotValidException ex) {
-        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(400,  ex.getMessage());
-        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<ApiErrorResponseDTO> handleInvalidPasswordException(InvalidPasswordException ex) {
+        ApiErrorResponseDTO errorResponse = new ApiErrorResponseDTO(401,  ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler(MissingAddressException.class)

--- a/backend/src/main/java/edu/zut/bookrider/exception/InvalidPasswordException.java
+++ b/backend/src/main/java/edu/zut/bookrider/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package edu.zut.bookrider.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException(String message){
+        super(message);
+    }
+}

--- a/backend/src/main/java/edu/zut/bookrider/exception/PasswordNotValidException.java
+++ b/backend/src/main/java/edu/zut/bookrider/exception/PasswordNotValidException.java
@@ -1,7 +1,0 @@
-package edu.zut.bookrider.exception;
-
-public class PasswordNotValidException extends RuntimeException {
-    public PasswordNotValidException(String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/edu/zut/bookrider/service/UserService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/UserService.java
@@ -103,22 +103,14 @@ public class UserService {
     }
 
     @Transactional
-    public void changePassword(Authentication authentication, String username, ChangePasswordDto changePasswordDto) {
-        User libraryAdmin = getUser(authentication);
-        Integer libraryId = libraryAdmin.getLibrary().getId();
+    public void changePassword(ChangePasswordDto changePasswordDto) {
+        User user = getUser();
 
-        User librarian = findLibrarianByUsernameAndLibraryId(username, libraryId);
-
-        if (!passwordEncoder.matches(changePasswordDto.getOldPassword(), librarian.getPassword())) {
+        if (!passwordEncoder.matches(changePasswordDto.getOldPassword(), user.getPassword())) {
             throw new InvalidPasswordException("Old password is not correct");
         }
 
-        if (!changePasswordDto.getNewPassword().equals(changePasswordDto.getConfirmPassword())) {
-            throw new InvalidPasswordException("The new password and its confirmation do not match");
-        }
-
-        librarian.setPassword(passwordEncoder.encode(changePasswordDto.getNewPassword()));
-        userRepository.save(librarian);
+        user.setPassword(passwordEncoder.encode(changePasswordDto.getNewPassword()));
+        userRepository.save(user);
     }
-
 }

--- a/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdministratorControllerIT.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdministratorControllerIT.java
@@ -1,5 +1,6 @@
 package edu.zut.bookrider.integration.controller;
 
+import com.jayway.jsonpath.JsonPath;
 import edu.zut.bookrider.model.Address;
 import edu.zut.bookrider.model.Library;
 import edu.zut.bookrider.model.Role;
@@ -18,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -171,21 +173,15 @@ public class LibraryAdministratorControllerIT {
 
         assertTrue(passwordEncoder.matches("password", librarianReference.getPassword()));
 
-        mockMvc.perform(MockMvcRequestBuilders.patch("/api/library-admins/librarians/reset-password/{username}", librarianReference.getUsername())
-                        .param("newPassword", "Password1@")
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.patch("/api/library-admins/librarians/reset-password/{username}", librarianReference.getUsername())
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andReturn();
 
-        assertTrue(passwordEncoder.matches("Password1@", librarianReference.getPassword()));
-    }
+        String response = result.getResponse().getContentAsString();
 
-    @Test
-    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
-    void whenWrongPasswordFormat_thenReturnBadRequest() throws Exception {
+        String tempPasswordValue = JsonPath.parse(response).read("$.tempPassword");
 
-        mockMvc.perform(MockMvcRequestBuilders.patch("/api/library-admins/librarians/reset-password/{username}", librarianReference.getUsername())
-                        .param("newPassword", "password")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isBadRequest());
+        assertTrue(passwordEncoder.matches(tempPasswordValue, librarianReference.getPassword()));
     }
 }

--- a/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/controller/LibraryAdministratorControllerTest.java
@@ -119,17 +119,18 @@ public class LibraryAdministratorControllerTest {
 
     @Test
     void resetLibrarianPassword_shouldReturnUpdatedLibrarian() throws Exception {
-        when(libraryAdministratorService.resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq(authentication)))
-                .thenReturn(librarianDTO);
+        when(libraryAdministratorService.resetLibrarianPassword(eq("test_user")))
+                .thenReturn(createLibrarianResponseDTO);
 
         mockMvc.perform(patch("/api/library-admins/librarians/reset-password/{username}", "test_user")
-                        .principal(authentication)
-                        .param("newPassword", "newPassword"))
+                        .principal(authentication))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("1"))
                 .andExpect(jsonPath("$.username").value("test_user"))
                 .andExpect(jsonPath("$.firstName").value("TestName"))
-                .andExpect(jsonPath("$.lastName").value("TestLastName"));
+                .andExpect(jsonPath("$.lastName").value("TestLastName"))
+                .andExpect(jsonPath("$.tempPassword").value("tempPassword"));
 
-        verify(libraryAdministratorService).resetLibrarianPassword(eq("test_user"), eq("newPassword"), eq(authentication));
+        verify(libraryAdministratorService).resetLibrarianPassword(eq("test_user"));
     }
 }

--- a/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/service/LibraryAdministratorServiceTest.java
@@ -2,7 +2,6 @@ package edu.zut.bookrider.unit.service;
 
 import edu.zut.bookrider.dto.CreateLibrarianResponseDTO;
 import edu.zut.bookrider.dto.LibrarianDTO;
-import edu.zut.bookrider.exception.PasswordNotValidException;
 import edu.zut.bookrider.exception.UserNotFoundException;
 import edu.zut.bookrider.mapper.user.LibrarianReadMapper;
 import edu.zut.bookrider.model.Library;
@@ -90,32 +89,28 @@ public class LibraryAdministratorServiceTest {
 
     @Test
     void resetLibrarianPassword_shouldResetPasswordSuccessfully() {
-        String newPassword = "NewP@ssw0rd";
+        String username = "Test username";
+        String generatedTempPassword = "tempPass";
+        String encodedPassword = "encodedTempPass";
 
-        LibrarianDTO librarianDTO = new LibrarianDTO("123", "Test username", "Test FirstName", "Test LastName");
-
-        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
-        when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
-        when(passwordEncoder.encode(newPassword)).thenReturn("newPassword");
+        when(userService.getUser()).thenReturn(libraryAdmin);
+        when(userService.findLibrarianByUsernameAndLibraryId(username, libraryAdmin.getLibrary().getId()))
+                .thenReturn(librarian);
+        when(passwordEncoder.encode(generatedTempPassword)).thenReturn(encodedPassword);
         when(userRepository.save(librarian)).thenReturn(librarian);
-        when(librarianReadMapper.map(librarian)).thenReturn(librarianDTO);
-
-        LibrarianDTO result = libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, authentication);
+        CreateLibrarianResponseDTO result = libraryAdministratorService.resetLibrarianPassword(username);
 
         assertNotNull(result);
-        assertEquals("Test username", result.getUsername());
-        assertEquals("Test FirstName", result.getFirstName());
-        assertEquals("Test LastName", result.getLastName());
-        assertEquals("123", result.getId());
-    }
+        assertEquals(librarian.getId(), result.getId());
+        assertEquals(username, result.getUsername());
+        assertEquals(librarian.getFirstName(), result.getFirstName());
+        assertEquals(librarian.getLastName(), result.getLastName());
+        assertNotNull(result.getTempPassword());
 
-    @Test
-    void resetLibrarianPassword_shouldThrowPasswordNotValidException_whenPasswordDoesNotMatchPattern() {
-        String newPassword = "invalidPassword";
-        when(userService.getUser(authentication)).thenReturn(libraryAdmin);
-        when(userService.findLibrarianByUsernameAndLibraryId("Test username", libraryAdmin.getLibrary().getId())).thenReturn(librarian);
-
-        assertThrows(PasswordNotValidException.class, () -> libraryAdministratorService.resetLibrarianPassword("Test username", newPassword, authentication));
+        verify(userService).getUser();
+        verify(userService).findLibrarianByUsernameAndLibraryId(username, libraryAdmin.getLibrary().getId());
+        verify(passwordEncoder).encode(anyString());
+        verify(userRepository).save(librarian);
     }
 
     @Test

--- a/backend/src/test/java/edu/zut/bookrider/unit/service/UserServiceTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/unit/service/UserServiceTest.java
@@ -1,20 +1,25 @@
 package edu.zut.bookrider.unit.service;
 
+import edu.zut.bookrider.dto.ChangePasswordDto;
+import edu.zut.bookrider.exception.InvalidPasswordException;
 import edu.zut.bookrider.model.Address;
 import edu.zut.bookrider.model.Library;
 import edu.zut.bookrider.model.Role;
 import edu.zut.bookrider.model.User;
 import edu.zut.bookrider.repository.UserRepository;
+import edu.zut.bookrider.security.SecurityUtils;
 import edu.zut.bookrider.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.Authentication;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -26,6 +31,9 @@ public class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @Test
     public void whenCorrectInput_thenDoNotThrowException() {
@@ -76,4 +84,98 @@ public class UserServiceTest {
         assertTrue(user.getIsVerified());
         verify(userRepository, times(1)).save(user);
     }
+
+    @Test
+    public void whenOldPasswordIsCorrect_andPasswordsMatch_thenChangePasswordSuccessfully() {
+        User libraryAdmin = new User();
+        libraryAdmin.setId("RANDOM");
+
+        Library library = new Library();
+        library.setId(1);
+
+        User librarian = new User();
+        librarian.setId("Random");
+        librarian.setUsername("librarian");
+        librarian.setPassword("password");
+        librarian.setLibrary(library);
+
+        ChangePasswordDto changePasswordDto = new ChangePasswordDto();
+        changePasswordDto.setOldPassword("oldPassword");
+        changePasswordDto.setNewPassword("newPassword");
+        changePasswordDto.setConfirmPassword("newPassword");
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn("librarian:1");
+
+        mockStatic(SecurityUtils.class);
+        when(SecurityUtils.getFirstAuthority()).thenReturn("ROLE_USER");
+
+        when(userRepository.findByUsernameAndLibraryId("librarian", 1)).thenReturn(Optional.of(librarian));
+        when(passwordEncoder.matches("oldPassword", "password")).thenReturn(true);
+        when(passwordEncoder.encode("newPassword")).thenReturn("encodedNewPassword");
+
+        userService.changePassword(authentication, "librarian", changePasswordDto);
+
+        assertEquals("encodedNewPassword", librarian.getPassword());
+        verify(userRepository, times(1)).save(librarian);
+    }
+
+    @Test
+    public void whenOldPasswordIsIncorrect_thenThrowInvalidPasswordException() {
+        User librarian = new User();
+        librarian.setId("Random");
+        librarian.setUsername("librarian");
+        librarian.setPassword("password");
+
+        Library library = new Library();
+        library.setId(1);
+        librarian.setLibrary(library);
+
+        ChangePasswordDto changePasswordDto = new ChangePasswordDto();
+        changePasswordDto.setOldPassword("wrongPassword");
+        changePasswordDto.setNewPassword("newPassword");
+        changePasswordDto.setConfirmPassword("newPassword");
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn("librarian:1");
+
+        when(userRepository.findByUsernameAndLibraryId("librarian", 1)).thenReturn(Optional.of(librarian));
+        when(passwordEncoder.matches("wrongPassword", "password")).thenReturn(false);
+
+        InvalidPasswordException exception = assertThrows(InvalidPasswordException.class, () -> {
+            userService.changePassword(authentication, "librarian", changePasswordDto);
+        });
+
+        assertEquals("Old password is not correct", exception.getMessage());
+    }
+
+    @Test
+    public void whenNewPasswordDoesNotMatchConfirmPassword_thenThrowInvalidPasswordException() {
+        User librarian = new User();
+        librarian.setId("Random");
+        librarian.setUsername("librarian");
+        librarian.setPassword("password");
+
+        Library library = new Library();
+        library.setId(1);
+        librarian.setLibrary(library);
+
+        ChangePasswordDto changePasswordDto = new ChangePasswordDto();
+        changePasswordDto.setOldPassword("oldPassword");
+        changePasswordDto.setNewPassword("newPassword");
+        changePasswordDto.setConfirmPassword("NewPassword");
+
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn("librarian:1");
+
+        when(userRepository.findByUsernameAndLibraryId("librarian", 1)).thenReturn(Optional.of(librarian));
+        when(passwordEncoder.matches("oldPassword", "password")).thenReturn(true);
+
+        InvalidPasswordException exception = assertThrows(InvalidPasswordException.class, () -> {
+            userService.changePassword(authentication, "librarian", changePasswordDto);
+        });
+
+        assertEquals("The new password and its confirmation do not match", exception.getMessage());
+    }
+
 }


### PR DESCRIPTION
Added endpoint for librarian to securely change their passwords, including validation for the old password and confirmation of the new password. Introduced a new DTO and custom exception for improved handling, with unit tests to check functionality 