### PR TITLE
Feature - 83 add input fields validation

### DIFF
--- a/backend/src/main/java/edu/zut/bookrider/controller/LibraryCardController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/LibraryCardController.java
@@ -2,6 +2,7 @@ package edu.zut.bookrider.controller;
 
 import edu.zut.bookrider.dto.LibraryCardDTO;
 import edu.zut.bookrider.service.LibraryCardService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ public class LibraryCardController {
     @PreAuthorize("hasRole('librarian')")
     @PostMapping
     public ResponseEntity<?> createLibraryCard(
-            @RequestBody LibraryCardDTO libraryCardDTO) {
+            @Valid @RequestBody LibraryCardDTO libraryCardDTO) {
 
         LibraryCardDTO responseDto = libraryCardService.addLibraryCard(libraryCardDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);

--- a/backend/src/main/java/edu/zut/bookrider/controller/OrderController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/OrderController.java
@@ -150,7 +150,7 @@ public class OrderController {
     @PostMapping("/{orderId}/deliver")
     public ResponseEntity<?> deliverOrder(
             @PathVariable Integer orderId,
-            @RequestBody DeliverOrderRequestDTO request) {
+            @Valid @RequestBody DeliverOrderRequestDTO request) {
 
         CreateTransactionResponseDTO response = orderService.deliverOrder(orderId, request);
 

--- a/backend/src/main/java/edu/zut/bookrider/controller/ShoppingCartController.java
+++ b/backend/src/main/java/edu/zut/bookrider/controller/ShoppingCartController.java
@@ -3,6 +3,7 @@ package edu.zut.bookrider.controller;
 import edu.zut.bookrider.dto.CreateAddressDTO;
 import edu.zut.bookrider.dto.ShoppingCartResponseDTO;
 import edu.zut.bookrider.service.ShoppingCartService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -19,7 +20,7 @@ public class ShoppingCartController {
     @PreAuthorize("hasRole('user')")
     @PostMapping("/address")
     public ResponseEntity<?> setDeliveryAddress(
-            @RequestBody CreateAddressDTO createAddressDTO,
+            @Valid @RequestBody CreateAddressDTO createAddressDTO,
             Authentication authentication) {
 
         ShoppingCartResponseDTO updatedShoppingCart = shoppingCartService.setDeliveryAddress(createAddressDTO, authentication);

--- a/backend/src/main/java/edu/zut/bookrider/dto/CoordinateDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CoordinateDTO.java
@@ -1,5 +1,7 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +10,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CoordinateDTO {
+
+    @NotBlank(message = "Latitude is required")
+    @Pattern(regexp = "\\d{1,2}\\.\\d+", message = "Latitude must be in the format 'DD.DDD...'")
     private double latitude;
+
+    @NotBlank(message = "Longitude is required")
+    @Pattern(regexp = "\\d{1,2}\\.\\d+", message = "Longitude must be in the format 'DD.DDD...'")
     private double longitude;
 }

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateAddressDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateAddressDTO.java
@@ -1,5 +1,7 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +10,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateAddressDTO {
+
+    @NotBlank(message = "Street is required")
     private String street;
+
+    @NotBlank(message = "City is required")
     private String city;
+
+    @NotBlank(message = "Postal code is required")
+    @Pattern(regexp = "\\d{2}-\\d{3}", message = "Postal code must be in format XX-XXX")
     private String postalCode;
 }

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateAdvancedAccountDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateAdvancedAccountDTO.java
@@ -1,5 +1,6 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateAdvancedAccountDTO {
     @NotBlank(message = "Email is required")
+    @Email(message = "Email must be a valid email address")
     private String email;
 
     @NotBlank(message = "FirstName is required")

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateDriverDocumentDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateDriverDocumentDTO.java
@@ -1,5 +1,8 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,7 +13,14 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateDriverDocumentDTO {
+
+    @NotNull(message = "Image is required")
     private byte[] imageInBytes;
+
+    @NotBlank(message = "Document type is required")
     private String documentType;
+
+    @NotNull(message = "Expiry date is required")
+    @Future(message = "Expiry date must be in the future")
     private LocalDate expiryDate;
 }

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateLibrarianDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateLibrarianDTO.java
@@ -1,6 +1,7 @@
 package edu.zut.bookrider.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 public class CreateLibrarianDTO {
 
     @NotNull(message = "Username cannot be null")
+    @Pattern(regexp = "^[^@]+$", message = "Username cannot be an email")
     private String username;
 
     @NotNull(message = "First name cannot be null")

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateLibraryAdditionDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateLibraryAdditionDTO.java
@@ -1,5 +1,8 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,10 +11,24 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateLibraryAdditionDTO {
+
+    @NotBlank(message = "Street is required")
     private String street;
+
+    @NotBlank(message = "City is required")
     private String city;
+
+    @NotBlank(message = "Postal code is required")
+    @Pattern(regexp = "\\d{2}-\\d{3}", message = "Postal code must be in format XX-XXX")
     private String postalCode;
+
+    @NotBlank(message = "Library name is required")
     private String libraryName;
+
+    @NotBlank(message = "Phone number is required")
     private String phoneNumber;
+
+    @NotBlank(message = "Library email is required")
+    @Email(message = "Library email must be a valid email address")
     private String libraryEmail;
 }

--- a/backend/src/main/java/edu/zut/bookrider/dto/CreateUserDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/CreateUserDTO.java
@@ -1,5 +1,6 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateUserDTO {
     @NotBlank(message = "Email is required")
+    @Email(message = "Email must be a valid email address")
     private String email;
 
     @NotBlank(message = "Password is required")

--- a/backend/src/main/java/edu/zut/bookrider/dto/LibraryCardDTO.java
+++ b/backend/src/main/java/edu/zut/bookrider/dto/LibraryCardDTO.java
@@ -1,5 +1,8 @@
 package edu.zut.bookrider.dto;
 
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,9 +16,19 @@ import java.time.LocalDate;
 @Builder
 public class LibraryCardDTO {
 
+    @NotBlank(message = "User id is required")
     private String userId;
+
+    @NotBlank(message = "Card id is required")
     private String cardId;
+
+    @NotBlank(message = "First name is required")
     private String firstName;
+
+    @NotBlank(message = "Last name is required")
     private String lastName;
+
+    @NotNull(message = "Expiration date must be not null")
+    @Future(message = "Expiration date must be in the future")
     private LocalDate expirationDate;
 }

--- a/backend/src/main/java/edu/zut/bookrider/service/AddressService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/AddressService.java
@@ -4,6 +4,7 @@ import edu.zut.bookrider.dto.CoordinateDTO;
 import edu.zut.bookrider.dto.CreateAddressDTO;
 import edu.zut.bookrider.model.Address;
 import edu.zut.bookrider.repository.AddressRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,7 +18,7 @@ public class AddressService {
     private final GeocodeService geocodeService;
     private final AddressRepository addressRepository;
 
-    public Address createAddress(CreateAddressDTO createAddressDTO) {
+    public Address createAddress(@Valid CreateAddressDTO createAddressDTO) {
         Address address = new Address();
 
         address.setStreet(createAddressDTO.getStreet());
@@ -36,7 +37,7 @@ public class AddressService {
         return addressRepository.save(address);
     }
 
-    public Optional<Address> findExistingAddress(CreateAddressDTO createAddressDTO) {
+    public Optional<Address> findExistingAddress(@Valid CreateAddressDTO createAddressDTO) {
         return addressRepository.findByStreetAndCityAndPostalCode(
                 createAddressDTO.getStreet(),
                 createAddressDTO.getCity(),

--- a/backend/src/main/java/edu/zut/bookrider/service/DistanceService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/DistanceService.java
@@ -5,6 +5,7 @@ import edu.zut.bookrider.dto.NavigationResponseDTO;
 import edu.zut.bookrider.model.DistanceCache;
 import edu.zut.bookrider.repository.DistanceCacheRepository;
 import edu.zut.bookrider.service.enums.TransportProfile;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,8 +20,8 @@ public class DistanceService {
     private final DistanceCacheRepository distanceCacheRepository;
 
     public BigDecimal getDistance(
-            CoordinateDTO startCoordinates,
-            CoordinateDTO endCoordinates) {
+            @Valid CoordinateDTO startCoordinates,
+            @Valid CoordinateDTO endCoordinates) {
 
         BigDecimal startLat = BigDecimal.valueOf(startCoordinates.getLatitude());
         BigDecimal startLon = BigDecimal.valueOf(startCoordinates.getLongitude());

--- a/backend/src/main/java/edu/zut/bookrider/service/DriverApplicationRequestService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/DriverApplicationRequestService.java
@@ -10,6 +10,7 @@ import edu.zut.bookrider.model.User;
 import edu.zut.bookrider.model.enums.DriverApplicationStatus;
 import edu.zut.bookrider.repository.DriverApplicationRequestRepository;
 import edu.zut.bookrider.repository.UserRepository;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -38,7 +39,7 @@ public class DriverApplicationRequestService {
     @Transactional
     public CreateDriverApplicationResponseDTO createDriverApplication(
             Authentication authentication,
-            List<CreateDriverDocumentDTO> documents) {
+            List<@Valid CreateDriverDocumentDTO> documents) {
 
         String driverEmail = authentication.getName().split(":")[0];
 

--- a/backend/src/main/java/edu/zut/bookrider/service/DriverDocumentService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/DriverDocumentService.java
@@ -6,6 +6,7 @@ import edu.zut.bookrider.model.DriverApplicationRequest;
 import edu.zut.bookrider.model.DriverDocument;
 import edu.zut.bookrider.repository.DriverDocumentRepository;
 import edu.zut.bookrider.util.BASE64DecodedMultipartFile;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,7 +21,7 @@ public class DriverDocumentService {
     private final DriverDocumentRepository driverDocumentRepository;
 
     public CreateDriverDocumentResponseDTO saveDriverDocument(
-            CreateDriverDocumentDTO documentDto,
+            @Valid CreateDriverDocumentDTO documentDto,
             DriverApplicationRequest applicationRequest
     ) throws IOException {
         MultipartFile multipartFile = new BASE64DecodedMultipartFile(documentDto.getImageInBytes());

--- a/backend/src/main/java/edu/zut/bookrider/service/NavigationService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/NavigationService.java
@@ -8,6 +8,7 @@ import edu.zut.bookrider.dto.NavigationResponseDTO;
 import edu.zut.bookrider.exception.ExternalApiException;
 import edu.zut.bookrider.exception.InvalidCoordinatesException;
 import edu.zut.bookrider.service.enums.TransportProfile;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -28,12 +29,12 @@ public class NavigationService {
 
     private final RestTemplate restTemplate;
 
-    public NavigationResponseDTO getDirectionsFromCoordinates(CoordinateDTO startCoordinates, CoordinateDTO endCoordinates, TransportProfile transportProfile) {
+    public NavigationResponseDTO getDirectionsFromCoordinates(@Valid CoordinateDTO startCoordinates, @Valid CoordinateDTO endCoordinates, TransportProfile transportProfile) {
         String jsonResponse = callApiForDirections(startCoordinates, endCoordinates, transportProfile);
         return parseApiResponseIntoNavigationDTO(jsonResponse);
     }
 
-    private String callApiForDirections(CoordinateDTO startCoordinates, CoordinateDTO endCoordinates, TransportProfile transportProfile) {
+    private String callApiForDirections(@Valid CoordinateDTO startCoordinates, @Valid CoordinateDTO endCoordinates, TransportProfile transportProfile) {
         String start = startCoordinates.getLongitude() + "," + startCoordinates.getLatitude();
         String end = endCoordinates.getLongitude() + "," + endCoordinates.getLatitude();
 

--- a/backend/src/main/java/edu/zut/bookrider/service/OrderService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/OrderService.java
@@ -15,6 +15,7 @@ import edu.zut.bookrider.model.enums.TransactionType;
 import edu.zut.bookrider.repository.OrderRepository;
 import edu.zut.bookrider.util.BASE64DecodedMultipartFile;
 import edu.zut.bookrider.util.LocationUtils;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -226,7 +227,7 @@ public class OrderService {
     }
 
     @Transactional
-    public void declineOrder(Integer orderId, DeclineOrderRequestDTO declineOrderRequestDTO) {
+    public void declineOrder(Integer orderId, @Valid DeclineOrderRequestDTO declineOrderRequestDTO) {
 
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("Order not found"));
@@ -263,7 +264,7 @@ public class OrderService {
     }
 
     public PageResponseDTO<CreateOrderResponseDTO> getDriverPendingOrdersWithDistance(
-            CoordinateDTO location, double maxDistanceInMeters, int page, int size) {
+            @Valid CoordinateDTO location, double maxDistanceInMeters, int page, int size) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
         Page<Order> pendingOrders = orderRepository.findAcceptedOrdersForDriverWithDistance(
@@ -359,7 +360,7 @@ public class OrderService {
     }
 
     @Transactional
-    public CreateTransactionResponseDTO deliverOrder(Integer orderId, DeliverOrderRequestDTO requestDTO) {
+    public CreateTransactionResponseDTO deliverOrder(Integer orderId, @Valid DeliverOrderRequestDTO requestDTO) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("Order not found"));
 

--- a/backend/src/main/java/edu/zut/bookrider/service/ShoppingCartService.java
+++ b/backend/src/main/java/edu/zut/bookrider/service/ShoppingCartService.java
@@ -7,6 +7,7 @@ import edu.zut.bookrider.mapper.shoppingCart.ShoppingCartMapper;
 import edu.zut.bookrider.model.*;
 import edu.zut.bookrider.repository.ShoppingCartRepository;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -150,7 +151,7 @@ public class ShoppingCartService {
     }
 
     public ShoppingCartResponseDTO setDeliveryAddress(
-            CreateAddressDTO createAddressDTO,
+            @Valid CreateAddressDTO createAddressDTO,
             Authentication authentication ) {
 
         User user = userService.getUser(authentication);

--- a/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdditionRequestControllerIT.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdditionRequestControllerIT.java
@@ -22,7 +22,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,14 +109,11 @@ public class LibraryAdditionRequestControllerIT {
 
         String jsonBody = objectMapper.writeValueAsString(createLibraryAdditionDTO);
 
-        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders.post("/api/library-requests")
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/library-requests")
                         .content(jsonBody)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andReturn();
-
-        String responseBody = mvcResult.getResponse().getContentAsString();
-        //System.out.println("Response Body: " + responseBody);
     }
 
     @Test

--- a/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdditionRequestControllerIT.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdditionRequestControllerIT.java
@@ -103,7 +103,7 @@ public class LibraryAdditionRequestControllerIT {
         CreateLibraryAdditionDTO createLibraryAdditionDTO = new CreateLibraryAdditionDTO();
         createLibraryAdditionDTO.setStreet("Wojska Polskiego 14");
         createLibraryAdditionDTO.setCity("Szczecin");
-        createLibraryAdditionDTO.setPostalCode("73123");
+        createLibraryAdditionDTO.setPostalCode("73-123");
         createLibraryAdditionDTO.setLibraryName("Filia nr. 5");
         createLibraryAdditionDTO.setPhoneNumber("123123123");
         createLibraryAdditionDTO.setLibraryEmail("filia5@szczecin.gov.pl");

--- a/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdministratorControllerIT.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/controller/LibraryAdministratorControllerIT.java
@@ -1,5 +1,7 @@
 package edu.zut.bookrider.integration.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.zut.bookrider.dto.CreateLibrarianDTO;
 import edu.zut.bookrider.model.Address;
 import edu.zut.bookrider.model.Library;
 import edu.zut.bookrider.model.Role;
@@ -26,7 +28,8 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Transactional
@@ -54,6 +57,9 @@ public class LibraryAdministratorControllerIT {
 
     @Autowired
     private LibraryRepository libraryRepository;
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     private User libraryAdminReference;
     private User librarianReference;
@@ -186,6 +192,44 @@ public class LibraryAdministratorControllerIT {
         mockMvc.perform(MockMvcRequestBuilders.patch("/api/library-admins/librarians/reset-password/{username}", librarianReference.getUsername())
                         .param("newPassword", "password")
                         .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenValidCreateLibrarianData_thenReturnCreatedAndLibrarian() throws Exception {
+
+        CreateLibrarianDTO createLibrarianDTO = new CreateLibrarianDTO();
+        createLibrarianDTO.setUsername("new_librarian");
+        createLibrarianDTO.setFirstName("Adam");
+        createLibrarianDTO.setLastName("Smith");
+
+        String jsonBody = objectMapper.writeValueAsString(createLibrarianDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/library-admins/librarians")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody))
+                .andExpect(status().isCreated())
+                .andExpect(content().string(notNullValue()))
+                .andExpect(jsonPath("$.username").value("new_librarian"))
+                .andExpect(jsonPath("$.firstName").value("Adam"))
+                .andExpect(jsonPath("$.lastName").value("Smith"));
+    }
+
+    @Test
+    @WithMockUser(username = "library_administator@gmail.com", roles = {"library_administrator"})
+    void whenEmailInLibrarianUsernameWhileCreateLibrarian_thenReturnBadRequest() throws Exception {
+
+        CreateLibrarianDTO createLibrarianDTO = new CreateLibrarianDTO();
+        createLibrarianDTO.setUsername("new_librarian@bookrider.com");
+        createLibrarianDTO.setFirstName("Adam");
+        createLibrarianDTO.setLastName("Smith");
+
+        String jsonBody = objectMapper.writeValueAsString(createLibrarianDTO);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/library-admins/librarians")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonBody))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/edu/zut/bookrider/integration/security/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/security/AuthControllerIntegrationTest.java
@@ -208,4 +208,21 @@ public class AuthControllerIntegrationTest {
         // To debug
         //System.out.println(mvcResult.getResponse().getContentAsString());
     }
+
+    @Test
+    public void whenInvalidUserEmailDuringRegister_thenReturnError() throws Exception {
+        String role = "user";
+        String jsonRequest = "{\"email\":\"test\", \"password\":\"password\"}";
+
+        mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post("/api/auth/register/user", role)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json("{\"code\":400,\"message\":\"{email=Email must be a valid email address}\"}"))
+                .andReturn();
+    }
 }

--- a/backend/src/test/java/edu/zut/bookrider/integration/security/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/edu/zut/bookrider/integration/security/AuthControllerIntegrationTest.java
@@ -16,7 +16,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,7 +67,7 @@ public class AuthControllerIntegrationTest {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 
-        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders
+        mockMvc.perform(MockMvcRequestBuilders
                 .post("/api/auth/login/{role}", role)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonRequest)
@@ -76,9 +75,6 @@ public class AuthControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
                 .andReturn();
-
-        // To debug
-        //System.out.println(mvcResult.getResponse().getHeader(HttpHeaders.AUTHORIZATION));
     }
 
     @Test
@@ -88,7 +84,7 @@ public class AuthControllerIntegrationTest {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 
-        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders
+        mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/auth/login/{role}", role)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonRequest)
@@ -96,9 +92,6 @@ public class AuthControllerIntegrationTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(content().json("{\"code\":401,\"message\":\"Invalid email or password.\"}"))
                 .andReturn();
-
-        // To debug
-        //System.out.println(mvcResult.getResponse().getContentAsString());
     }
 
     @Test
@@ -116,7 +109,7 @@ public class AuthControllerIntegrationTest {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 
-        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders
+        mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/auth/login/{role}", role)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonRequest)
@@ -124,9 +117,6 @@ public class AuthControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
                 .andReturn();
-
-        // To debug
-        //System.out.println(mvcResult.getResponse().getHeader(HttpHeaders.AUTHORIZATION));
     }
 
     @Test
@@ -136,7 +126,7 @@ public class AuthControllerIntegrationTest {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 
-        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders
+        mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/auth/login/{role}", role)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonRequest)
@@ -144,9 +134,6 @@ public class AuthControllerIntegrationTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(content().json("{\"code\":401,\"message\":\"Invalid email or password.\"}"))
                 .andReturn();
-
-        // To debug
-        //System.out.println(mvcResult.getResponse().getContentAsString());
     }
 
     @Test
@@ -177,7 +164,7 @@ public class AuthControllerIntegrationTest {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 
-        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders
+        mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/auth/login/librarian")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonRequest)
@@ -185,9 +172,6 @@ public class AuthControllerIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(header().exists(HttpHeaders.AUTHORIZATION))
                 .andReturn();
-
-        // To debug
-        //System.out.println(mvcResult.getResponse().getHeader(HttpHeaders.AUTHORIZATION));
     }
 
     @Test
@@ -196,7 +180,7 @@ public class AuthControllerIntegrationTest {
 
         mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
 
-        MvcResult mvcResult = mockMvc.perform(MockMvcRequestBuilders
+        mockMvc.perform(MockMvcRequestBuilders
                         .post("/api/auth/login/librarian")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonRequest)
@@ -204,9 +188,6 @@ public class AuthControllerIntegrationTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(content().json("{\"code\":401,\"message\":\"Invalid email or password.\"}"))
                 .andReturn();
-
-        // To debug
-        //System.out.println(mvcResult.getResponse().getContentAsString());
     }
 
     @Test


### PR DESCRIPTION
I've added in the missing spots  validation for input DTO fields,  on service layer , and controller layer validation . However , i didn't fully understand the problem :  "librarians identifiers CAN'T be emails; every other role identifier MUST be an email" is a bit unclear to me. How it could have been fixed , what exactly needs to do .

If I understand correctly, it is necessary to add a  some validator  for Dto, which on the basis of the role, will check for all roles except librarian identifier for the correct email, and for librarians  identifier will be something else than email . Let me know if I mean that correctly   